### PR TITLE
Refactor 018/11 real time compatibility for earthquakes

### DIFF
--- a/Source/Common/LocalizationService.cs
+++ b/Source/Common/LocalizationService.cs
@@ -292,16 +292,34 @@ namespace NaturalDisastersRenewal.Common
                         { "settings.warmup_period.days", " days" },
                         {
                             "settings.earthquake.max_probability.tooltip",
-                            "Maximum occurrence (per year) after a long period without earthquakes."
+                            "Maximum occurrence per year after a long period without earthquakes when Real Time is inactive."
                         },
                         {
                             "settings.earthquake.warmup.tooltip",
-                            "The probability of earthquake increases to the maximum during this period."
+                            "The probability and maximum intensity of earthquakes increase during this period when Real Time is inactive."
                         },
+                        {
+                            "settings.earthquake.realtime_frequency",
+                            "Real Time earthquake frequency"
+                        },
+                        {
+                            "settings.earthquake.realtime_frequency.tooltip.selected",
+                            "Chooses the random real-time seismic interval used between automatic earthquakes while Real Time is active.\nAftershocks use shorter intervals and nearby epicenters.\nSelected reference period: {0}."
+                        },
+                        { "settings.earthquake.frequency.apocalypse", "Apocalypse: 30-60 minutes" },
+                        { "settings.earthquake.frequency.frequent", "Frequent: 90 minutes-3 hours" },
+                        { "settings.earthquake.frequency.occasional", "Occasional: 4-8 hours" },
+                        { "settings.earthquake.frequency.uncommon", "Uncommon: 8-16 hours" },
+                        { "settings.earthquake.frequency.rare", "Rare: 16-32 hours" },
+                        { "settings.earthquake.frequency_name.apocalypse", "Apocalypse" },
+                        { "settings.earthquake.frequency_name.frequent", "Frequent" },
+                        { "settings.earthquake.frequency_name.occasional", "Occasional" },
+                        { "settings.earthquake.frequency_name.uncommon", "Uncommon" },
+                        { "settings.earthquake.frequency_name.rare", "Rare" },
                         { "settings.enable_aftershocks", "Enable aftershocks" },
                         {
                             "settings.enable_aftershocks.tooltip",
-                            "Several aftershocks may occur after a big earthquake. Aftershocks strike the same place."
+                            "Several aftershocks may occur after a big earthquake. Aftershocks strike near the main epicenter."
                         },
                         { "settings.ground_cracks", "Cracks in the ground:" },
                         {
@@ -430,6 +448,19 @@ namespace NaturalDisastersRenewal.Common
                             "Tornado progress is increased by rain right now: progress advances at {0}%."
                         },
                         { "tooltip.earthquake.aftershocks", "Expect {0} more aftershocks" },
+                        {
+                            "tooltip.earthquake.realtime_active",
+                            "Real Time active: earthquakes use seismic intervals."
+                        },
+                        { "tooltip.earthquake.realtime_reference", "Reference seismic interval: {0}." },
+                        { "tooltip.earthquake.current_seismic_interval", "Current seismic interval: {0}." },
+                        { "tooltip.earthquake.seismic_time_remaining", "Seismic progress remaining: {0}." },
+                        {
+                            "tooltip.earthquake.realtime_aftershocks_active",
+                            "Real Time active: aftershocks use short intervals and nearby epicenters."
+                        },
+                        { "tooltip.earthquake.current_aftershock_interval", "Current aftershock interval: {0}." },
+                        { "tooltip.earthquake.aftershock_time_remaining", "Aftershock progress remaining: {0}." },
                         { "tooltip.meteor.realtime_reference", "Reference period: {0}." },
                         { "disaster.earthquake", "Earthquake" },
                         { "disaster.forest_fire", "Forest Fire" },
@@ -739,16 +770,34 @@ namespace NaturalDisastersRenewal.Common
                         { "settings.warmup_period.days", " dias" },
                         {
                             "settings.earthquake.max_probability.tooltip",
-                            "Ocurrencia maxima por ano despues de un largo periodo sin terremotos."
+                            "Ocurrencia maxima por ano despues de un largo periodo sin terremotos cuando Real Time no esta activo."
                         },
                         {
                             "settings.earthquake.warmup.tooltip",
-                            "La probabilidad del terremoto aumenta al maximo durante este periodo."
+                            "La probabilidad y la intensidad maxima de terremotos aumentan durante este periodo cuando Real Time no esta activo."
                         },
+                        {
+                            "settings.earthquake.realtime_frequency",
+                            "Frecuencia de terremotos con Real Time"
+                        },
+                        {
+                            "settings.earthquake.realtime_frequency.tooltip.selected",
+                            "Elige el intervalo sismico aleatorio en tiempo real entre terremotos automaticos mientras Real Time esta activo.\nLas replicas usan intervalos mas cortos y epicentros cercanos.\nPeriodo de referencia seleccionado: {0}."
+                        },
+                        { "settings.earthquake.frequency.apocalypse", "Apocalipsis: 30-60 minutos" },
+                        { "settings.earthquake.frequency.frequent", "Frecuente: 90 minutos-3 horas" },
+                        { "settings.earthquake.frequency.occasional", "Ocasional: 4-8 horas" },
+                        { "settings.earthquake.frequency.uncommon", "Poco frecuente: 8-16 horas" },
+                        { "settings.earthquake.frequency.rare", "Raro: 16-32 horas" },
+                        { "settings.earthquake.frequency_name.apocalypse", "Apocalipsis" },
+                        { "settings.earthquake.frequency_name.frequent", "Frecuente" },
+                        { "settings.earthquake.frequency_name.occasional", "Ocasional" },
+                        { "settings.earthquake.frequency_name.uncommon", "Poco frecuente" },
+                        { "settings.earthquake.frequency_name.rare", "Raro" },
                         { "settings.enable_aftershocks", "Activar replicas" },
                         {
                             "settings.enable_aftershocks.tooltip",
-                            "Pueden ocurrir varias replicas despues de un gran terremoto. Las replicas golpean la misma zona."
+                            "Pueden ocurrir varias replicas despues de un gran terremoto. Las replicas golpean cerca del epicentro principal."
                         },
                         { "settings.ground_cracks", "Grietas en el suelo:" },
                         {
@@ -874,6 +923,19 @@ namespace NaturalDisastersRenewal.Common
                             "La lluvia aumenta el progreso de tornado ahora: el progreso avanza al {0}%."
                         },
                         { "tooltip.earthquake.aftershocks", "Se esperan {0} replicas mas" },
+                        {
+                            "tooltip.earthquake.realtime_active",
+                            "Real Time activo: los terremotos usan intervalos sismicos."
+                        },
+                        { "tooltip.earthquake.realtime_reference", "Intervalo sismico de referencia: {0}." },
+                        { "tooltip.earthquake.current_seismic_interval", "Intervalo sismico actual: {0}." },
+                        { "tooltip.earthquake.seismic_time_remaining", "Progreso sismico restante: {0}." },
+                        {
+                            "tooltip.earthquake.realtime_aftershocks_active",
+                            "Real Time activo: las replicas usan intervalos cortos y epicentros cercanos."
+                        },
+                        { "tooltip.earthquake.current_aftershock_interval", "Intervalo de replica actual: {0}." },
+                        { "tooltip.earthquake.aftershock_time_remaining", "Progreso de replica restante: {0}." },
                         { "tooltip.meteor.realtime_reference", "Periodo de referencia: {0}." },
                         { "disaster.earthquake", "Terremoto" },
                         { "disaster.forest_fire", "Incendio forestal" },

--- a/Source/Common/LocalizationService.cs
+++ b/Source/Common/LocalizationService.cs
@@ -144,6 +144,17 @@ namespace NaturalDisastersRenewal.Common
                             "settings.frequency_harmony.mismatch.tooltip",
                             "Does not match the General frequency harmonizer."
                         },
+                        { "settings.debug.progress.group", "Debug disaster progress" },
+                        { "settings.debug.progress.disaster", "Disaster" },
+                        {
+                            "settings.debug.progress.disaster.tooltip",
+                            "DEBUG only. Selects which disaster receives the test progress value."
+                        },
+                        { "settings.debug.progress.percent", "Set progress" },
+                        {
+                            "settings.debug.progress.percent.tooltip",
+                            "DEBUG only. Sets the selected disaster progress for testing. 100% forces the next occurrence attempt."
+                        },
                         { "settings.frequency.apocalypse", "Apocalypse" },
                         { "settings.frequency.frequent", "Frequent" },
                         { "settings.frequency.occasional", "Occasional" },
@@ -621,6 +632,17 @@ namespace NaturalDisastersRenewal.Common
                         {
                             "settings.frequency_harmony.mismatch.tooltip",
                             "No coincide con el armonizador de frecuencia de General."
+                        },
+                        { "settings.debug.progress.group", "Progreso de desastres para debug" },
+                        { "settings.debug.progress.disaster", "Desastre" },
+                        {
+                            "settings.debug.progress.disaster.tooltip",
+                            "Solo DEBUG. Selecciona que desastre recibe el valor de progreso de prueba."
+                        },
+                        { "settings.debug.progress.percent", "Definir progreso" },
+                        {
+                            "settings.debug.progress.percent.tooltip",
+                            "Solo DEBUG. Define el progreso del desastre seleccionado para pruebas. 100% fuerza el proximo intento de ocurrencia."
                         },
                         { "settings.frequency.apocalypse", "Apocalipsis" },
                         { "settings.frequency.frequent", "Frecuente" },

--- a/Source/Models/NaturalDisaster/DisasterBaseModel.cs
+++ b/Source/Models/NaturalDisaster/DisasterBaseModel.cs
@@ -23,6 +23,7 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
         protected const byte indexReferenceDisasterValue = 10;
         private readonly HashSet<ushort> manualReleaseDisasters = new HashSet<ushort>();
         private readonly double secondsBeforePausing = 3;
+        private bool debugForceOccurrence;
         private DateTime lastStartFailureLogUtc = DateTime.MinValue;
         public float BaseOccurrencePerYear = 1.0f;
 
@@ -63,6 +64,9 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
         public float GetCurrentOccurrencePerYear()
         {
             if (calmDaysLeft > 0) return 0f;
+
+            if (debugForceOccurrence)
+                return 365f / GetSimulationDaysPerFrame() * 2f;
 
             return ScaleProbabilityByWarmup(GetCurrentOccurrencePerYearLocal());
         }
@@ -193,6 +197,19 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
 
         public virtual void OnEnabledChanged(bool enabled)
         {
+        }
+
+        public virtual void SetDebugProbabilityProgress(float progress)
+        {
+            var clampedProgress = Mathf.Clamp01(progress);
+            debugForceOccurrence = clampedProgress >= 0.999f;
+            calmDaysLeft = 0f;
+
+            if (probabilityWarmupDays > 0)
+                probabilityWarmupDaysLeft = probabilityWarmupDays * (1f - clampedProgress);
+
+            if (intensityWarmupDays > 0)
+                intensityWarmupDaysLeft = intensityWarmupDays * (1f - clampedProgress);
         }
 
         public DisasterType GetDisasterType()
@@ -520,6 +537,7 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             expr_98_cp_0[expr_98_cp_1].m_flags = expr_98_cp_0[expr_98_cp_1].m_flags | DisasterData.Flags.SelfTrigger;
             disasterInfo.m_disasterAI.StartNow(disasterIndex, ref dm.m_disasters.m_buffer[disasterIndex]);
             AfterStartDisaster(disasterIndex);
+            debugForceOccurrence = false;
 
             DebugLogger.Log(GetDebugStr() + string.Format(
                 "StartNow called. Id: {0}, Flags: {1}, Intensity: {2}, Area: {3}, Target: x:{4:#.##} y:{5:#.##} z:{6:#.##}",

--- a/Source/Models/NaturalDisaster/DisasterBaseModel.cs
+++ b/Source/Models/NaturalDisaster/DisasterBaseModel.cs
@@ -476,6 +476,10 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
         {
         }
 
+        protected virtual void AfterStartDisaster(ushort disasterId)
+        {
+        }
+
         public abstract bool CheckDisasterAIType(object disasterAI);
 
         protected void StartDisaster(byte intensity)
@@ -515,6 +519,7 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             var expr_98_cp_1 = disasterIndex;
             expr_98_cp_0[expr_98_cp_1].m_flags = expr_98_cp_0[expr_98_cp_1].m_flags | DisasterData.Flags.SelfTrigger;
             disasterInfo.m_disasterAI.StartNow(disasterIndex, ref dm.m_disasters.m_buffer[disasterIndex]);
+            AfterStartDisaster(disasterIndex);
 
             DebugLogger.Log(GetDebugStr() + string.Format(
                 "StartNow called. Id: {0}, Flags: {1}, Intensity: {2}, Area: {3}, Target: x:{4:#.##} y:{5:#.##} z:{6:#.##}",

--- a/Source/Models/NaturalDisaster/DisasterBaseModel.cs
+++ b/Source/Models/NaturalDisaster/DisasterBaseModel.cs
@@ -24,6 +24,7 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
         private readonly HashSet<ushort> manualReleaseDisasters = new HashSet<ushort>();
         private readonly double secondsBeforePausing = 3;
         private bool debugForceOccurrence;
+        private float debugProbabilityProgressOverride = -1f;
         private DateTime lastStartFailureLogUtc = DateTime.MinValue;
         public float BaseOccurrencePerYear = 1.0f;
 
@@ -202,6 +203,7 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
         public virtual void SetDebugProbabilityProgress(float progress)
         {
             var clampedProgress = Mathf.Clamp01(progress);
+            debugProbabilityProgressOverride = clampedProgress;
             debugForceOccurrence = clampedProgress >= 0.999f;
             calmDaysLeft = 0f;
 
@@ -210,6 +212,12 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
 
             if (intensityWarmupDays > 0)
                 intensityWarmupDaysLeft = intensityWarmupDays * (1f - clampedProgress);
+        }
+
+        public bool TryGetDebugProbabilityProgress(out float progress)
+        {
+            progress = debugProbabilityProgressOverride;
+            return debugProbabilityProgressOverride >= 0f;
         }
 
         public DisasterType GetDisasterType()
@@ -538,6 +546,7 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             disasterInfo.m_disasterAI.StartNow(disasterIndex, ref dm.m_disasters.m_buffer[disasterIndex]);
             AfterStartDisaster(disasterIndex);
             debugForceOccurrence = false;
+            debugProbabilityProgressOverride = -1f;
 
             DebugLogger.Log(GetDebugStr() + string.Format(
                 "StartNow called. Id: {0}, Flags: {1}, Intensity: {2}, Area: {3}, Target: x:{4:#.##} y:{5:#.##} z:{6:#.##}",

--- a/Source/Models/NaturalDisaster/EarthquakeModel.cs
+++ b/Source/Models/NaturalDisaster/EarthquakeModel.cs
@@ -545,6 +545,22 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             return probabilityWarmupDays <= 0 || probabilityWarmupDaysLeft <= 0f;
         }
 
+        public override void SetDebugProbabilityProgress(float progress)
+        {
+            base.SetDebugProbabilityProgress(progress);
+
+            if (IsRealTimePatternActive())
+            {
+                ScheduleNextRealTimeEarthquake(progress);
+                InvalidateRealTimeAftershockSchedule();
+                aftershocksCount = 0;
+                ClearRealTimeCooldownState();
+                return;
+            }
+
+            aftershocksCount = 0;
+        }
+
         private string GetRealTimeProbabilityTooltip(float probabilityValue)
         {
             if (!unlocked) return LocalizationService.Get("tooltip.not_unlocked");

--- a/Source/Models/NaturalDisaster/EarthquakeModel.cs
+++ b/Source/Models/NaturalDisaster/EarthquakeModel.cs
@@ -119,7 +119,9 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
                     ? 365f / GetSimulationDaysPerFrame() * GuaranteedOccurrencePerFrame
                     : 0f;
 
-            return base.GetCurrentOccurrencePerYearLocal();
+            return IsEarthquakeCharged()
+                ? 365f / GetSimulationDaysPerFrame() * GuaranteedOccurrencePerFrame
+                : 0f;
         }
 
         protected override float GetSimulationDaysPerFrame()
@@ -516,6 +518,31 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
 
             EnsureRealTimeEarthquakeSchedule();
             return Mathf.Clamp01(1f - RealTimeMinutesUntilNextEarthquake / RealTimeCurrentSeismicPeriodMinutes);
+        }
+
+        public float GetProbabilityProgress()
+        {
+            if (!unlocked)
+                return 0f;
+
+            if (IsRealTimePatternActive())
+                return GetRealTimePatternProbabilityProgress();
+
+            if (aftershocksCount > 0)
+                return 1f;
+
+            if (calmDaysLeft > 0)
+                return 0f;
+
+            if (probabilityWarmupDays <= 0 || probabilityWarmupDaysLeft <= 0f)
+                return 1f;
+
+            return Mathf.Clamp01(1f - probabilityWarmupDaysLeft / probabilityWarmupDays);
+        }
+
+        private bool IsEarthquakeCharged()
+        {
+            return probabilityWarmupDays <= 0 || probabilityWarmupDaysLeft <= 0f;
         }
 
         private string GetRealTimeProbabilityTooltip(float probabilityValue)

--- a/Source/Models/NaturalDisaster/EarthquakeModel.cs
+++ b/Source/Models/NaturalDisaster/EarthquakeModel.cs
@@ -12,6 +12,25 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
 {
     public class EarthquakeModel : DisasterBaseModel
     {
+        private const float GuaranteedOccurrencePerFrame = 2f;
+        private const float SecondsPerMinute = 60f;
+        private const float MaxRealTimeDeltaSeconds = 5f;
+        private const int NearbyAftershockTargetAttempts = 16;
+        private const float MinimumAftershockRadius = 128f;
+        private const float MaximumAftershockRadius = 960f;
+        private const float AftershockRadiusPerIntensityPoint = 10f;
+        private const string ExtendedInfoPanel2ModKey = "extendedInfoPanel2";
+        private static readonly RealTimeDisasterFrequencyPreset[] RealTimeEarthquakeFrequencyOptionValues =
+        {
+            RealTimeDisasterFrequencyPreset.Apocalypse,
+            RealTimeDisasterFrequencyPreset.Frequent,
+            RealTimeDisasterFrequencyPreset.Occasional,
+            RealTimeDisasterFrequencyPreset.Uncommon,
+            RealTimeDisasterFrequencyPreset.Rare
+        };
+
+        [XmlIgnore] private float _lastRealTimeScheduleUpdateSeconds = -1f;
+        [XmlIgnore] private readonly HashSet<ushort> _pendingDetectionEarthquakes = new HashSet<ushort>();
         [XmlIgnore] public byte aftershockMaxIntensity;
         [XmlIgnore] public byte aftershocksCount;
         public bool AftershocksEnabled = true;
@@ -20,6 +39,12 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
         [XmlIgnore] public Vector3 lastTargetPosition;
         [XmlIgnore] public byte mainStrikeIntensity;
         public float MinimalIntensityForCracks = 12.0f;
+        [XmlIgnore] public float RealTimeCurrentAftershockPeriodMinutes = -1f;
+        [XmlIgnore] public float RealTimeCurrentSeismicPeriodMinutes = -1f;
+        public RealTimeDisasterFrequencyPreset RealTimeEarthquakeFrequency =
+            RealTimeDisasterFrequencyPreset.Occasional;
+        [XmlIgnore] public float RealTimeMinutesUntilNextAftershock = -1f;
+        [XmlIgnore] public float RealTimeMinutesUntilNextEarthquake = -1f;
 
         [XmlIgnore] private bool NoCracksInTheGroud;
 
@@ -49,16 +74,66 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
         public override string GetProbabilityTooltip(float value)
         {
             if (aftershocksCount > 0)
+            {
+                if (IsRealTimePatternActive())
+                    return GetRealTimeAftershockProbabilityTooltip(value);
+
                 return LocalizationService.Format("tooltip.earthquake.aftershocks", aftershocksCount);
+            }
+
+            if (IsRealTimePatternActive())
+                return GetRealTimeProbabilityTooltip(value);
 
             return base.GetProbabilityTooltip(value);
         }
 
+        protected override void OnSimulationFrameLocal()
+        {
+            RetryPendingEarthquakeDetections();
+
+            if (!IsRealTimePatternActive())
+                return;
+
+            ClearRealTimeCooldownState();
+
+            if (aftershocksCount > 0)
+            {
+                UpdateRealTimeAftershockSchedule();
+                return;
+            }
+
+            UpdateRealTimeEarthquakeSchedule();
+        }
+
         protected override float GetCurrentOccurrencePerYearLocal()
         {
-            if (aftershocksCount > 0) return 12 * aftershocksCount;
+            if (aftershocksCount > 0)
+                return IsRealTimePatternActive()
+                    ? IsRealTimeAftershockDue()
+                        ? 365f / GetSimulationDaysPerFrame() * GuaranteedOccurrencePerFrame
+                        : 0f
+                    : 12 * aftershocksCount;
+
+            if (IsRealTimePatternActive())
+                return IsRealTimeEarthquakeDue()
+                    ? 365f / GetSimulationDaysPerFrame() * GuaranteedOccurrencePerFrame
+                    : 0f;
 
             return base.GetCurrentOccurrencePerYearLocal();
+        }
+
+        protected override float GetSimulationDaysPerFrame()
+        {
+            return IsRealTimePatternActive()
+                ? DisasterSimulationUtils.VanillaSimulationDaysPerFrame
+                : base.GetSimulationDaysPerFrame();
+        }
+
+        public override byte GetMaximumIntensity()
+        {
+            return IsRealTimePatternActive()
+                ? ScaleIntensityByPopulation(baseIntensity)
+                : base.GetMaximumIntensity();
         }
 
         public override void OnDisasterActivated(DisasterSettings disasterInfo, ushort disasterId,
@@ -66,6 +141,55 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
         {
             disasterInfo.type |= DisasterType.Earthquake;
             base.OnDisasterActivated(disasterInfo, disasterId, ref activeDisasters);
+            DetectActiveEarthquake(disasterId);
+        }
+
+        protected override void AfterStartDisaster(ushort disasterId)
+        {
+            if (!TryForceDetectEarthquake(disasterId))
+                _pendingDetectionEarthquakes.Add(disasterId);
+        }
+
+        private void DetectActiveEarthquake(ushort disasterId)
+        {
+            TryForceDetectEarthquake(disasterId);
+        }
+
+        private void RetryPendingEarthquakeDetections()
+        {
+            if (_pendingDetectionEarthquakes.Count == 0)
+                return;
+
+            var detected = new List<ushort>();
+            foreach (var disasterId in _pendingDetectionEarthquakes)
+                if (TryForceDetectEarthquake(disasterId))
+                    detected.Add(disasterId);
+
+            for (var i = 0; i < detected.Count; i++)
+                _pendingDetectionEarthquakes.Remove(detected[i]);
+        }
+
+        private bool TryForceDetectEarthquake(ushort disasterId)
+        {
+            if (!Enabled || disasterId == 0)
+                return true;
+
+            var dm = Services.Disasters;
+            var flags = dm.m_disasters.m_buffer[disasterId].m_flags;
+            if ((flags & DisasterData.Flags.Detected) != 0)
+                return true;
+
+            if ((flags & (DisasterData.Flags.Emerging | DisasterData.Flags.Active)) == 0)
+                return true;
+
+            dm.DetectDisaster(disasterId, true);
+            DebugLogger.Log(GetDebugStr() + string.Format(
+                "Earthquake forced detection. Id: {0}, Flags: {1}",
+                disasterId,
+                dm.m_disasters.m_buffer[disasterId].m_flags));
+
+            flags = dm.m_disasters.m_buffer[disasterId].m_flags;
+            return (flags & DisasterData.Flags.Active) != 0 || (flags & DisasterData.Flags.Detected) != 0;
         }
 
         public override void OnDisasterDeactivated(DisasterInfoModel disasterInfoUnified,
@@ -95,11 +219,21 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             if (!AftershocksEnabled)
             {
                 aftershocksCount = 0;
+                InvalidateRealTimeAftershockSchedule();
+                if (IsRealTimePatternActive())
+                {
+                    ResetRealTimeEarthquakeSchedule();
+                    ClearRealTimeCooldownState();
+                    return;
+                }
+
                 base.OnDisasterStarted(intensity);
                 return;
             }
 
-            if (aftershocksCount == 0)
+            var isAftershock = aftershocksCount > 0;
+
+            if (!isAftershock)
             {
                 mainStrikeIntensity = intensity;
                 aftershockMaxIntensity = (byte)(10 + (intensity - 10) * 3 / 4);
@@ -114,9 +248,17 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
 
             if (aftershocksCount > 0)
             {
-                calmDays = 15;
-                probabilityWarmupDaysLeft = 0;
-                intensityWarmupDaysLeft = 0;
+                if (IsRealTimePatternActive())
+                {
+                    ScheduleNextRealTimeAftershock();
+                    ClearRealTimeCooldownState();
+                }
+                else
+                {
+                    calmDays = 15;
+                    probabilityWarmupDaysLeft = 0;
+                    intensityWarmupDaysLeft = 0;
+                }
 
                 Debug.Log(string.Format(
                     CommonProperties.LogMessagePrefix + "{0} aftershocks are still going to happen.",
@@ -124,7 +266,17 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             }
             else
             {
+                if (IsRealTimePatternActive())
+                {
+                    ResetRealTimeEarthquakeSchedule();
+                    InvalidateRealTimeAftershockSchedule();
+                    ClearRealTimeCooldownState();
+                    return;
+                }
+
+                calmDays = GetMainEarthquakeCalmDays();
                 base.OnDisasterStarted(mainStrikeIntensity);
+                calmDays = GetMainEarthquakeCalmDays();
             }
         }
 
@@ -133,10 +285,27 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             if (aftershocksCount == 0)
             {
                 var result = base.FindTarget(disasterInfo, out targetPosition, out angle);
-                lastTargetPosition = targetPosition;
-                lastAngle = angle;
+                if (!result && TryFindRandomTargetInConfiguredArea(out targetPosition, out angle))
+                {
+                    DebugLogger.Log(GetDebugStr() + string.Format(
+                        "Earthquake fallback target selected. Target: x:{0:#.##} y:{1:#.##} z:{2:#.##}",
+                        targetPosition.x,
+                        targetPosition.y,
+                        targetPosition.z));
+                    result = true;
+                }
+
+                if (result)
+                {
+                    lastTargetPosition = targetPosition;
+                    lastAngle = angle;
+                }
+
                 return result;
             }
+
+            if (TryFindNearbyAftershockTarget(out targetPosition, out angle))
+                return true;
 
             targetPosition = lastTargetPosition;
             angle = lastAngle;
@@ -278,7 +447,7 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
 
                             case EarthquakeCrackOptions eco when eco == EarthquakeCrackOptions.CracksBasedOnIntensity &&
                                                                  disasterInfoModel.DisasterInfo.intensity >=
-                                                                 MinimalIntensityForCracks:
+                                                                 MinimalIntensityForCracks * 10:
                                 IgnoreDestructionZoneForEarthquake = false;
                                 break;
 
@@ -326,6 +495,464 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             UpdateDisasterProperties(true);
         }
 
+        public bool IsRealTimePatternActive()
+        {
+            return DisasterSimulationUtils.IsRealTimeModActive();
+        }
+
+        public override void OnEnabledChanged(bool enabled)
+        {
+            _lastRealTimeScheduleUpdateSeconds = Time.realtimeSinceStartup;
+        }
+
+        public float GetRealTimePatternProbabilityProgress()
+        {
+            if (aftershocksCount > 0)
+            {
+                EnsureRealTimeAftershockSchedule();
+                return Mathf.Clamp01(1f - RealTimeMinutesUntilNextAftershock /
+                    RealTimeCurrentAftershockPeriodMinutes);
+            }
+
+            EnsureRealTimeEarthquakeSchedule();
+            return Mathf.Clamp01(1f - RealTimeMinutesUntilNextEarthquake / RealTimeCurrentSeismicPeriodMinutes);
+        }
+
+        private string GetRealTimeProbabilityTooltip(float probabilityValue)
+        {
+            if (!unlocked) return LocalizationService.Get("tooltip.not_unlocked");
+
+            EnsureRealTimeEarthquakeSchedule();
+            return string.Format(
+                "{0}: {1}{2}{3}{2}{4}{2}{5}{2}{6}",
+                LocalizationService.Get("tooltip.progress"),
+                string.Format("{0:00.00}%", probabilityValue * 100),
+                CommonProperties.NewLine,
+                LocalizationService.Get("tooltip.earthquake.realtime_active"),
+                LocalizationService.Format("tooltip.earthquake.realtime_reference", GetRealTimeEarthquakeFrequencyName()),
+                LocalizationService.Format(
+                    "tooltip.earthquake.current_seismic_interval",
+                    DisasterSimulationUtils.FormatRealTimeMinutes(RealTimeCurrentSeismicPeriodMinutes)),
+                LocalizationService.Format(
+                    "tooltip.earthquake.seismic_time_remaining",
+                    DisasterSimulationUtils.FormatRealTimeMinutes(RealTimeMinutesUntilNextEarthquake)));
+        }
+
+        private string GetRealTimeAftershockProbabilityTooltip(float probabilityValue)
+        {
+            EnsureRealTimeAftershockSchedule();
+            return string.Format(
+                "{0}: {1}{2}{3}{2}{4}{2}{5}{2}{6}",
+                LocalizationService.Get("tooltip.progress"),
+                string.Format("{0:00.00}%", probabilityValue * 100),
+                CommonProperties.NewLine,
+                LocalizationService.Format("tooltip.earthquake.aftershocks", aftershocksCount),
+                LocalizationService.Get("tooltip.earthquake.realtime_aftershocks_active"),
+                LocalizationService.Format(
+                    "tooltip.earthquake.current_aftershock_interval",
+                    DisasterSimulationUtils.FormatRealTimeMinutes(RealTimeCurrentAftershockPeriodMinutes)),
+                LocalizationService.Format(
+                    "tooltip.earthquake.aftershock_time_remaining",
+                    DisasterSimulationUtils.FormatRealTimeMinutes(RealTimeMinutesUntilNextAftershock)));
+        }
+
+        private void UpdateRealTimeEarthquakeSchedule()
+        {
+            EnsureRealTimeEarthquakeSchedule();
+
+            RealTimeMinutesUntilNextEarthquake = Mathf.Max(
+                0f,
+                RealTimeMinutesUntilNextEarthquake - GetRealTimeElapsedMinutes());
+        }
+
+        private void UpdateRealTimeAftershockSchedule()
+        {
+            EnsureRealTimeAftershockSchedule();
+
+            RealTimeMinutesUntilNextAftershock = Mathf.Max(
+                0f,
+                RealTimeMinutesUntilNextAftershock - GetRealTimeElapsedMinutes());
+        }
+
+        private bool IsRealTimeEarthquakeDue()
+        {
+            EnsureRealTimeEarthquakeSchedule();
+            return RealTimeMinutesUntilNextEarthquake <= 0f;
+        }
+
+        private bool IsRealTimeAftershockDue()
+        {
+            EnsureRealTimeAftershockSchedule();
+            return RealTimeMinutesUntilNextAftershock <= 0f;
+        }
+
+        private void EnsureRealTimeEarthquakeSchedule()
+        {
+            if (RealTimeCurrentSeismicPeriodMinutes <= 0f || RealTimeMinutesUntilNextEarthquake < 0f)
+                ScheduleNextRealTimeEarthquake();
+
+            if (RealTimeMinutesUntilNextEarthquake > RealTimeCurrentSeismicPeriodMinutes)
+                RealTimeMinutesUntilNextEarthquake = RealTimeCurrentSeismicPeriodMinutes;
+        }
+
+        private void EnsureRealTimeAftershockSchedule()
+        {
+            if (RealTimeCurrentAftershockPeriodMinutes <= 0f || RealTimeMinutesUntilNextAftershock < 0f)
+                ScheduleNextRealTimeAftershock();
+
+            if (RealTimeMinutesUntilNextAftershock > RealTimeCurrentAftershockPeriodMinutes)
+                RealTimeMinutesUntilNextAftershock = RealTimeCurrentAftershockPeriodMinutes;
+        }
+
+        private void ResetRealTimeEarthquakeSchedule()
+        {
+            ScheduleNextRealTimeEarthquake();
+        }
+
+        private void ScheduleNextRealTimeEarthquake()
+        {
+            ScheduleNextRealTimeEarthquake(0f);
+        }
+
+        private void ScheduleNextRealTimeEarthquake(float progressToKeep)
+        {
+            var progress = Mathf.Clamp01(progressToKeep);
+            RealTimeCurrentSeismicPeriodMinutes = GetRandomRealTimeIntervalMinutes();
+            RealTimeMinutesUntilNextEarthquake = RealTimeCurrentSeismicPeriodMinutes * (1f - progress);
+            _lastRealTimeScheduleUpdateSeconds = Time.realtimeSinceStartup;
+        }
+
+        private void ScheduleNextRealTimeAftershock()
+        {
+            RealTimeCurrentAftershockPeriodMinutes = GetRandomRealTimeAftershockIntervalMinutes();
+            RealTimeMinutesUntilNextAftershock = RealTimeCurrentAftershockPeriodMinutes;
+            _lastRealTimeScheduleUpdateSeconds = Time.realtimeSinceStartup;
+        }
+
+        private void InvalidateRealTimeAftershockSchedule()
+        {
+            RealTimeCurrentAftershockPeriodMinutes = -1f;
+            RealTimeMinutesUntilNextAftershock = -1f;
+        }
+
+        private void ClearRealTimeCooldownState()
+        {
+            calmDaysLeft = 0f;
+            probabilityWarmupDaysLeft = 0f;
+            intensityWarmupDaysLeft = 0f;
+        }
+
+        private float GetRealTimeElapsedMinutes()
+        {
+            var currentSeconds = Time.realtimeSinceStartup;
+
+            if (_lastRealTimeScheduleUpdateSeconds < 0f)
+            {
+                _lastRealTimeScheduleUpdateSeconds = currentSeconds;
+                return 0f;
+            }
+
+            var elapsedSeconds = Mathf.Clamp(
+                currentSeconds - _lastRealTimeScheduleUpdateSeconds,
+                0f,
+                MaxRealTimeDeltaSeconds);
+            _lastRealTimeScheduleUpdateSeconds = currentSeconds;
+            return elapsedSeconds / SecondsPerMinute * GetRealTimeSpeedFactor();
+        }
+
+        private static float GetRealTimeSpeedFactor()
+        {
+            var simulation = Services.Simulation;
+            if (simulation == null || simulation.SimulationPaused)
+                return 0f;
+
+            var speed = Mathf.Max(1, simulation.FinalSimulationSpeed);
+            if (ModCompatibilityService.IsActive(ExtendedInfoPanel2ModKey))
+                return GetExtendedInfoPanelSpeedFactor(speed);
+
+            return GetVanillaSpeedFactor(speed);
+        }
+
+        private static float GetVanillaSpeedFactor(int speed)
+        {
+            if (speed <= 1)
+                return 1f;
+
+            return speed == 2 ? 1.5f : 2f;
+        }
+
+        private static float GetExtendedInfoPanelSpeedFactor(int speed)
+        {
+            if (speed <= 3)
+                return GetVanillaSpeedFactor(speed);
+
+            switch (speed)
+            {
+                case 4:
+                    return 2.5f;
+                case 5:
+                    return 3f;
+                default:
+                    return 3.5f;
+            }
+        }
+
+        private float GetRandomRealTimeIntervalMinutes()
+        {
+            GetRealTimeIntervalRange(out var minMinutes, out var maxMinutes);
+
+            var randomValue = Services.Simulation.m_randomizer.Int32(0, 10000) / 10000f;
+            return minMinutes + (maxMinutes - minMinutes) * randomValue;
+        }
+
+        private void GetRealTimeIntervalRange(out float minMinutes, out float maxMinutes)
+        {
+            switch (RealTimeEarthquakeFrequency)
+            {
+                case RealTimeDisasterFrequencyPreset.Apocalypse:
+                    minMinutes = 30f;
+                    maxMinutes = 60f;
+                    break;
+                case RealTimeDisasterFrequencyPreset.Frequent:
+                    minMinutes = 90f;
+                    maxMinutes = 180f;
+                    break;
+                case RealTimeDisasterFrequencyPreset.Occasional:
+                default:
+                    minMinutes = 240f;
+                    maxMinutes = 480f;
+                    break;
+                case RealTimeDisasterFrequencyPreset.Uncommon:
+                    minMinutes = 480f;
+                    maxMinutes = 960f;
+                    break;
+                case RealTimeDisasterFrequencyPreset.Rare:
+                    minMinutes = 960f;
+                    maxMinutes = 1920f;
+                    break;
+            }
+        }
+
+        private float GetRandomRealTimeAftershockIntervalMinutes()
+        {
+            var randomValue = Services.Simulation.m_randomizer.Int32(0, 10000) / 10000f;
+            return 5f + 25f * randomValue;
+        }
+
+        private bool TryFindNearbyAftershockTarget(out Vector3 targetPosition, out float angle)
+        {
+            targetPosition = Vector3.zero;
+            angle = 0f;
+
+            if (lastTargetPosition == Vector3.zero)
+                return false;
+
+            var simulation = Services.Simulation;
+            var terrain = Services.Terrain;
+            if (simulation == null || terrain == null)
+                return false;
+
+            var radius = Mathf.Clamp(
+                mainStrikeIntensity * AftershockRadiusPerIntensityPoint,
+                MinimumAftershockRadius,
+                MaximumAftershockRadius);
+
+            for (var attempt = 0; attempt < NearbyAftershockTargetAttempts; attempt++)
+            {
+                var randomAngle = simulation.m_randomizer.Int32(0, 10000) * 0.0006283185f;
+                var randomDistance = Mathf.Sqrt(simulation.m_randomizer.Int32(0, 10000) / 10000f) * radius;
+                var candidate = lastTargetPosition;
+                candidate.x += Mathf.Cos(randomAngle) * randomDistance;
+                candidate.z += Mathf.Sin(randomAngle) * randomDistance;
+                candidate.y = terrain.SampleRawHeightSmoothWithWater(candidate, false, 0f);
+
+                if (!IsAftershockTargetAllowed(candidate))
+                    continue;
+
+                targetPosition = candidate;
+                angle = randomAngle;
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool IsAftershockTargetAllowed(Vector3 position)
+        {
+            var area = unlocked ? OccurrenceAreaAfterUnlock : OccurrenceAreaBeforeUnlock;
+
+            switch (area)
+            {
+                case OccurrenceAreas.Everywhere:
+                    return true;
+
+                case OccurrenceAreas.UnlockedAreas:
+                    return TryGetAreaCoordinates(position, out var unlockedX, out var unlockedZ) &&
+                           IsAreaUnlocked(unlockedX, unlockedZ);
+
+                case OccurrenceAreas.LockedAreas:
+                    return TryGetAreaCoordinates(position, out var lockedX, out var lockedZ) &&
+                           !IsAreaUnlocked(lockedX, lockedZ);
+
+                default:
+                    return false;
+            }
+        }
+
+        private bool TryFindRandomTargetInConfiguredArea(out Vector3 targetPosition, out float angle)
+        {
+            targetPosition = Vector3.zero;
+            angle = 0f;
+
+            var gameArea = Services.GameArea;
+            var simulation = Services.Simulation;
+            var terrain = Services.Terrain;
+            if (gameArea == null || simulation == null || terrain == null)
+                return false;
+
+            var area = unlocked ? OccurrenceAreaAfterUnlock : OccurrenceAreaBeforeUnlock;
+            var allowedAreaCount = 0;
+            var selectedX = -1;
+            var selectedZ = -1;
+
+            for (var z = 0; z < 5; z++)
+            for (var x = 0; x < 5; x++)
+            {
+                var isUnlocked = IsAreaUnlocked(x, z);
+                var allowed = area == OccurrenceAreas.Everywhere ||
+                              area == OccurrenceAreas.UnlockedAreas && isUnlocked ||
+                              area == OccurrenceAreas.LockedAreas && !isUnlocked;
+                if (!allowed)
+                    continue;
+
+                allowedAreaCount++;
+                if (simulation.m_randomizer.Int32((uint)allowedAreaCount) == 0)
+                {
+                    selectedX = x;
+                    selectedZ = z;
+                }
+            }
+
+            if (selectedX < 0 || selectedZ < 0)
+                return false;
+
+            float minX;
+            float minZ;
+            float maxX;
+            float maxZ;
+            gameArea.GetAreaBounds(selectedX, selectedZ, out minX, out minZ, out maxX, out maxZ);
+
+            var randomX = simulation.m_randomizer.Int32(0, 10000) * 0.0001f;
+            var randomZ = simulation.m_randomizer.Int32(0, 10000) * 0.0001f;
+            targetPosition.x = minX + (maxX - minX) * randomX;
+            targetPosition.z = minZ + (maxZ - minZ) * randomZ;
+            targetPosition.y = terrain.SampleRawHeightSmoothWithWater(targetPosition, false, 0f);
+            angle = simulation.m_randomizer.Int32(0, 10000) * 0.0006283185f;
+            return true;
+        }
+
+        private static bool TryGetAreaCoordinates(Vector3 position, out int areaX, out int areaZ)
+        {
+            var gameArea = Services.GameArea;
+            for (var x = 0; x < 5; x++)
+            for (var z = 0; z < 5; z++)
+            {
+                float minX;
+                float minZ;
+                float maxX;
+                float maxZ;
+                gameArea.GetAreaBounds(x, z, out minX, out minZ, out maxX, out maxZ);
+                if (position.x >= minX && position.x <= maxX && position.z >= minZ && position.z <= maxZ)
+                {
+                    areaX = x;
+                    areaZ = z;
+                    return true;
+                }
+            }
+
+            areaX = 0;
+            areaZ = 0;
+            return false;
+        }
+
+        private static bool IsAreaUnlocked(int areaX, int areaZ)
+        {
+            return areaX >= 0 && areaZ >= 0 && areaX < 5 && areaZ < 5 &&
+                   Services.GameArea.m_areaGrid[areaZ * 5 + areaX] != 0;
+        }
+
+        private int GetMainEarthquakeCalmDays()
+        {
+            return probabilityWarmupDays / 2;
+        }
+
+        public void SetRealTimeEarthquakeFrequency(RealTimeDisasterFrequencyPreset frequency)
+        {
+            if (RealTimeEarthquakeFrequency == frequency)
+                return;
+
+            EnsureRealTimeEarthquakeSchedule();
+            var currentProgress = Mathf.Clamp01(1f - RealTimeMinutesUntilNextEarthquake /
+                RealTimeCurrentSeismicPeriodMinutes);
+            RealTimeEarthquakeFrequency = frequency;
+            ScheduleNextRealTimeEarthquake(currentProgress);
+        }
+
+        public static string[] GetRealTimeEarthquakeFrequencyOptions()
+        {
+            return new[]
+            {
+                LocalizationService.Get("settings.earthquake.frequency.apocalypse"),
+                LocalizationService.Get("settings.earthquake.frequency.frequent"),
+                LocalizationService.Get("settings.earthquake.frequency.occasional"),
+                LocalizationService.Get("settings.earthquake.frequency.uncommon"),
+                LocalizationService.Get("settings.earthquake.frequency.rare")
+            };
+        }
+
+        public int GetRealTimeEarthquakeFrequencySelectionIndex()
+        {
+            for (var i = 0; i < RealTimeEarthquakeFrequencyOptionValues.Length; i++)
+                if (RealTimeEarthquakeFrequencyOptionValues[i] == RealTimeEarthquakeFrequency)
+                    return i;
+
+            return 2;
+        }
+
+        public static RealTimeDisasterFrequencyPreset GetRealTimeEarthquakeFrequencyFromSelection(int selection)
+        {
+            if (selection < 0 || selection >= RealTimeEarthquakeFrequencyOptionValues.Length)
+                return RealTimeDisasterFrequencyPreset.Occasional;
+
+            return RealTimeEarthquakeFrequencyOptionValues[selection];
+        }
+
+        public string GetRealTimeEarthquakeFrequencyTooltip()
+        {
+            return LocalizationService.Format(
+                "settings.earthquake.realtime_frequency.tooltip.selected",
+                GetRealTimeEarthquakeFrequencyName());
+        }
+
+        private string GetRealTimeEarthquakeFrequencyName()
+        {
+            switch (RealTimeEarthquakeFrequency)
+            {
+                case RealTimeDisasterFrequencyPreset.Apocalypse:
+                    return LocalizationService.Get("settings.earthquake.frequency_name.apocalypse");
+                case RealTimeDisasterFrequencyPreset.Frequent:
+                    return LocalizationService.Get("settings.earthquake.frequency_name.frequent");
+                case RealTimeDisasterFrequencyPreset.Occasional:
+                    return LocalizationService.Get("settings.earthquake.frequency_name.occasional");
+                case RealTimeDisasterFrequencyPreset.Uncommon:
+                    return LocalizationService.Get("settings.earthquake.frequency_name.uncommon");
+                case RealTimeDisasterFrequencyPreset.Rare:
+                    return LocalizationService.Get("settings.earthquake.frequency_name.rare");
+                default:
+                    return RealTimeEarthquakeFrequency.ToString();
+            }
+        }
+
         public void UpdateDisasterProperties(bool isSet)
         {
             var prefabsCount = PrefabCollection<DisasterInfo>.PrefabCount();
@@ -360,6 +987,7 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             {
                 AftershocksEnabled = earthquake.AftershocksEnabled;
                 WarmupYears = earthquake.WarmupYears;
+                SetRealTimeEarthquakeFrequency(earthquake.RealTimeEarthquakeFrequency);
             }
         }
     }

--- a/Source/Models/NaturalDisaster/ForestFireModel.cs
+++ b/Source/Models/NaturalDisaster/ForestFireModel.cs
@@ -595,6 +595,25 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             ScheduleNextRealTimeForestFire(currentProgress);
         }
 
+        public override void SetDebugProbabilityProgress(float progress)
+        {
+            base.SetDebugProbabilityProgress(progress);
+
+            var clampedProgress = Mathf.Clamp01(progress);
+            calmDaysLeft = 0f;
+            probabilityWarmupDaysLeft = 0f;
+            intensityWarmupDaysLeft = 0f;
+
+            if (IsRealTimePatternActive())
+            {
+                ScheduleNextRealTimeForestFire(clampedProgress);
+                NoRainDays = WarmupDays * clampedProgress;
+                return;
+            }
+
+            NoRainDays = WarmupDays * clampedProgress;
+        }
+
         public static string[] GetRealTimeForestFireFrequencyOptions()
         {
             return new[]

--- a/Source/Models/NaturalDisaster/MeteorStrikeModel.cs
+++ b/Source/Models/NaturalDisaster/MeteorStrikeModel.cs
@@ -269,6 +269,28 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             return progress;
         }
 
+        public override void SetDebugProbabilityProgress(float progress)
+        {
+            base.SetDebugProbabilityProgress(progress);
+
+            var clampedProgress = Mathf.Clamp01(progress);
+            calmDaysLeft = 0f;
+            probabilityWarmupDaysLeft = 0f;
+            intensityWarmupDaysLeft = 0f;
+
+            if (IsRealTimePatternActive())
+            {
+                ScheduleNextRealTimeMeteor(clampedProgress);
+                return;
+            }
+
+            for (var i = 0; i < MeteorEvents.Length; i++)
+            {
+                MeteorEvents[i].MeteorsFallen = 0;
+                MeteorEvents[i].DaysUntilNextEvent = MeteorEvents[i].PeriodDays * (1f - clampedProgress);
+            }
+        }
+
         public float GetRealTimePatternProbabilityProgress()
         {
             EnsureRealTimeSchedule();

--- a/Source/Models/NaturalDisaster/SinkholeModel.cs
+++ b/Source/Models/NaturalDisaster/SinkholeModel.cs
@@ -873,6 +873,20 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             ScheduleNextRealTimeSinkhole(currentProgress);
         }
 
+        public override void SetDebugProbabilityProgress(float progress)
+        {
+            base.SetDebugProbabilityProgress(progress);
+
+            var clampedProgress = Mathf.Clamp01(progress);
+            calmDaysLeft = 0f;
+            probabilityWarmupDaysLeft = 0f;
+            intensityWarmupDaysLeft = 0f;
+            groundwaterAmount = GroundwaterCapacity * clampedProgress;
+
+            if (IsRealTimePatternActive())
+                ScheduleNextRealTimeSinkhole(clampedProgress);
+        }
+
         public static string[] GetRealTimeSinkholeFrequencyOptions()
         {
             return new[]

--- a/Source/Models/NaturalDisaster/ThunderstormModel.cs
+++ b/Source/Models/NaturalDisaster/ThunderstormModel.cs
@@ -351,6 +351,20 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             ScheduleNextRealTimeThunderstorm(currentProgress);
         }
 
+        public override void SetDebugProbabilityProgress(float progress)
+        {
+            base.SetDebugProbabilityProgress(progress);
+
+            if (IsRealTimePatternActive())
+            {
+                ScheduleNextRealTimeThunderstorm(progress);
+                calmDaysLeft = 0f;
+                probabilityWarmupDaysLeft = 0f;
+                intensityWarmupDaysLeft = 0f;
+                return;
+            }
+        }
+
         public static string[] GetRealTimeThunderstormFrequencyOptions()
         {
             return new[]

--- a/Source/Models/NaturalDisaster/TornadoModel.cs
+++ b/Source/Models/NaturalDisaster/TornadoModel.cs
@@ -467,6 +467,18 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             ScheduleNextRealTimeTornado(currentProgress);
         }
 
+        public override void SetDebugProbabilityProgress(float progress)
+        {
+            base.SetDebugProbabilityProgress(progress);
+
+            if (IsRealTimePatternActive())
+            {
+                ScheduleNextRealTimeTornado(progress);
+                ClearRealTimeCooldownState();
+                return;
+            }
+        }
+
         public static string[] GetRealTimeTornadoFrequencyOptions()
         {
             return new[]

--- a/Source/Serialization/NaturalDisaster/SerializableDataEarthquake.cs
+++ b/Source/Serialization/NaturalDisaster/SerializableDataEarthquake.cs
@@ -27,6 +27,12 @@ namespace NaturalDisastersRenewal.Serialization.NaturalDisaster
             dataSerializer.WriteFloat(earthquake.lastTargetPosition.y);
             dataSerializer.WriteFloat(earthquake.lastTargetPosition.z);
             dataSerializer.WriteFloat(earthquake.lastAngle);
+
+            dataSerializer.WriteInt32((int)earthquake.RealTimeEarthquakeFrequency);
+            dataSerializer.WriteFloat(earthquake.RealTimeCurrentSeismicPeriodMinutes);
+            dataSerializer.WriteFloat(earthquake.RealTimeMinutesUntilNextEarthquake);
+            dataSerializer.WriteFloat(earthquake.RealTimeCurrentAftershockPeriodMinutes);
+            dataSerializer.WriteFloat(earthquake.RealTimeMinutesUntilNextAftershock);
         }
 
         public void Deserialize(DataSerializer dataSerializer)
@@ -50,6 +56,16 @@ namespace NaturalDisastersRenewal.Serialization.NaturalDisaster
 
             earthquake.lastTargetPosition = new Vector3(dataSerializer.ReadFloat(), dataSerializer.ReadFloat(), dataSerializer.ReadFloat());
             earthquake.lastAngle = dataSerializer.ReadFloat();
+
+            if (dataSerializer.version >= 16)
+            {
+                earthquake.RealTimeEarthquakeFrequency =
+                    (RealTimeDisasterFrequencyPreset)dataSerializer.ReadInt32();
+                earthquake.RealTimeCurrentSeismicPeriodMinutes = dataSerializer.ReadFloat();
+                earthquake.RealTimeMinutesUntilNextEarthquake = dataSerializer.ReadFloat();
+                earthquake.RealTimeCurrentAftershockPeriodMinutes = dataSerializer.ReadFloat();
+                earthquake.RealTimeMinutesUntilNextAftershock = dataSerializer.ReadFloat();
+            }
         }
 
         public void AfterDeserialize(DataSerializer s)

--- a/Source/Serialization/Setup/LoadedGameSerializableDataExtension.cs
+++ b/Source/Serialization/Setup/LoadedGameSerializableDataExtension.cs
@@ -12,7 +12,7 @@ namespace NaturalDisastersRenewal.Serialization.Setup
     public class LoadedGameSerializableDataExtension : ISerializableDataExtension
     {
         private const string DataID = CommonProperties.DataId;
-        private const uint DataVersion = 15;
+        private const uint DataVersion = 16;
         private ISerializableData _serializableData;
 
         public void OnCreated(ISerializableData serializedData)

--- a/Source/UI/ComponentHelper/DisasterRowHelper.cs
+++ b/Source/UI/ComponentHelper/DisasterRowHelper.cs
@@ -104,6 +104,8 @@ namespace NaturalDisastersRenewal.UI.ComponentHelper
                     return forestFire.GetRealTimePatternProbabilityProgress();
                 case TornadoModel tornado when tornado.IsRealTimePatternActive():
                     return tornado.GetRealTimePatternProbabilityProgress();
+                case EarthquakeModel earthquake when earthquake.IsRealTimePatternActive():
+                    return earthquake.GetRealTimePatternProbabilityProgress();
                 default:
                     return GetProbabilityProgressValueLog(occurrencePerYear);
             }

--- a/Source/UI/ComponentHelper/DisasterRowHelper.cs
+++ b/Source/UI/ComponentHelper/DisasterRowHelper.cs
@@ -104,8 +104,8 @@ namespace NaturalDisastersRenewal.UI.ComponentHelper
                     return forestFire.GetRealTimePatternProbabilityProgress();
                 case TornadoModel tornado when tornado.IsRealTimePatternActive():
                     return tornado.GetRealTimePatternProbabilityProgress();
-                case EarthquakeModel earthquake when earthquake.IsRealTimePatternActive():
-                    return earthquake.GetRealTimePatternProbabilityProgress();
+                case EarthquakeModel earthquake:
+                    return earthquake.GetProbabilityProgress();
                 default:
                     return GetProbabilityProgressValueLog(occurrencePerYear);
             }

--- a/Source/UI/ComponentHelper/DisasterRowHelper.cs
+++ b/Source/UI/ComponentHelper/DisasterRowHelper.cs
@@ -90,6 +90,9 @@ namespace NaturalDisastersRenewal.UI.ComponentHelper
 
         private float GetProbabilityProgressValue(float occurrencePerYear)
         {
+            if (Disaster.TryGetDebugProbabilityProgress(out var debugProgress))
+                return debugProgress;
+
             switch (Disaster)
             {
                 case MeteorStrikeModel meteorStrike:

--- a/Source/UI/ModSettingsScreen.cs
+++ b/Source/UI/ModSettingsScreen.cs
@@ -58,6 +58,11 @@ namespace NaturalDisastersRenewal.UI
         private UICheckBox UI_General_RecordDisasterEventsChkBox;
         private UICheckBox UI_General_ShowDisasterPanelButton;
         private UITextField UI_General_TogglePanelHotkeyField;
+#if DEBUG
+        private UIDropDown UI_Debug_DisasterProgressTarget;
+        private UISlider UI_Debug_DisasterProgress;
+        private int debugDisasterProgressTargetIndex;
+#endif
 
         //Forest Fire
         private UICheckBox UI_ForestFire_Enabled;
@@ -660,6 +665,11 @@ namespace NaturalDisastersRenewal.UI
             UI_General_RecordDisasterEventsChkBox = null;
             UI_General_ShowDisasterPanelButton = null;
             UI_General_TogglePanelHotkeyField = null;
+#if DEBUG
+            UI_Debug_DisasterProgressTarget = null;
+            UI_Debug_DisasterProgress = null;
+            debugDisasterProgressTargetIndex = 0;
+#endif
             UI_ForestFire_Enabled = null;
             UI_ForestFireMaxProbability = null;
             UI_ForestFire_WarmupDays = null;
@@ -889,6 +899,10 @@ namespace NaturalDisastersRenewal.UI
                 GetRealTimeFrequencyHarmonySelectionIndex(disasterContainer.RealTimeFrequencyHarmony);
             UI_General_RealTimeFrequencyHarmony.tooltip = GetRealTimeFrequencyHarmonyTooltip();
 
+#if DEBUG
+            AddDebugDisasterProgressControls(ref generalGroup, disasterContainer);
+#endif
+
             generalGroup.AddSpacing();
 
             var elementPositionsGroup = generalGroup.AddGroup(LocalizationService.Get("settings.positions"));
@@ -905,6 +919,65 @@ namespace NaturalDisastersRenewal.UI
                 UpdateSetupContentUI();
             });
         }
+
+#if DEBUG
+        private void AddDebugDisasterProgressControls(ref UIHelperBase generalGroup, DisasterSetupModel disasterContainer)
+        {
+            var debugGroup = generalGroup.AddGroup(LocalizationService.Get("settings.debug.progress.group"));
+            var disasterNames = GetDebugDisasterProgressTargetOptions(disasterContainer);
+
+            UI_Debug_DisasterProgressTarget = (UIDropDown)debugGroup.AddDropdown(
+                LocalizationService.Get("settings.debug.progress.disaster"),
+                disasterNames,
+                debugDisasterProgressTargetIndex,
+                delegate(int selection)
+                {
+                    if (_freezeUI)
+                        return;
+
+                    debugDisasterProgressTargetIndex = Mathf.Clamp(selection, 0, disasterContainer.AllDisasters.Count - 1);
+                });
+            UI_Debug_DisasterProgressTarget.tooltip = LocalizationService.Get("settings.debug.progress.disaster.tooltip");
+            UIStyleHelper.ApplyDropDownStyle(UI_Debug_DisasterProgressTarget);
+
+            UI_Debug_DisasterProgress = SliderHelper.AddSlider(
+                ref debugGroup,
+                LocalizationService.Get("settings.debug.progress.percent"),
+                0f,
+                100f,
+                1f,
+                0f,
+                delegate(float value)
+                {
+                    if (_freezeUI)
+                        return;
+
+                    ApplyDebugDisasterProgress(disasterContainer, debugDisasterProgressTargetIndex, value / 100f);
+                },
+                "%",
+                LocalizationService.Get("settings.debug.progress.percent.tooltip"));
+        }
+
+        private static string[] GetDebugDisasterProgressTargetOptions(DisasterSetupModel disasterContainer)
+        {
+            var names = new string[disasterContainer.AllDisasters.Count];
+            for (var i = 0; i < disasterContainer.AllDisasters.Count; i++)
+                names[i] = disasterContainer.AllDisasters[i].GetName();
+
+            return names;
+        }
+
+        private static void ApplyDebugDisasterProgress(
+            DisasterSetupModel disasterContainer,
+            int disasterIndex,
+            float progress)
+        {
+            if (disasterIndex < 0 || disasterIndex >= disasterContainer.AllDisasters.Count)
+                return;
+
+            disasterContainer.AllDisasters[disasterIndex].SetDebugProbabilityProgress(progress);
+        }
+#endif
 
         private static string[] GetRealTimeFrequencyHarmonyOptions()
         {

--- a/Source/UI/ModSettingsScreen.cs
+++ b/Source/UI/ModSettingsScreen.cs
@@ -114,6 +114,8 @@ namespace NaturalDisastersRenewal.UI
         private UISlider UI_Earthquake_MaxProbability;
         private UISlider UI_Earthquake_WarmupYears;
         private UICheckBox UI_Earthquake_AftershocksEnabled;
+        private UIDropDown UI_Earthquake_RealTimeFrequency;
+        private UISprite UI_Earthquake_RealTimeFrequencyWarning;
 
         //UICheckBox UI_Earthquake_NoCrack;
         private UIDropDown UI_Earthquake_CrackMode;
@@ -259,6 +261,11 @@ namespace NaturalDisastersRenewal.UI
             UI_Earthquake_MaxProbability.value = disasterSetupModel.Earthquake.BaseOccurrencePerYear;
             UI_Earthquake_WarmupYears.value = disasterSetupModel.Earthquake.WarmupYears;
             UI_Earthquake_AftershocksEnabled.isChecked = disasterSetupModel.Earthquake.AftershocksEnabled;
+            UI_Earthquake_RealTimeFrequency.selectedIndex =
+                disasterSetupModel.Earthquake.GetRealTimeEarthquakeFrequencySelectionIndex();
+            UI_Earthquake_RealTimeFrequency.tooltip =
+                disasterSetupModel.Earthquake.GetRealTimeEarthquakeFrequencyTooltip();
+            SetEarthquakeRealTimeControlsAvailability(disasterSetupModel.Earthquake.IsRealTimePatternActive());
             UI_Earthquake_CrackMode.selectedIndex = (int)disasterSetupModel.Earthquake.EarthquakeCrackMode;
 
             UI_MeteorStrike_Enabled.isChecked = disasterSetupModel.MeteorStrike.Enabled;
@@ -689,6 +696,8 @@ namespace NaturalDisastersRenewal.UI
             UI_Earthquake_MaxProbability = null;
             UI_Earthquake_WarmupYears = null;
             UI_Earthquake_AftershocksEnabled = null;
+            UI_Earthquake_RealTimeFrequency = null;
+            UI_Earthquake_RealTimeFrequencyWarning = null;
             UI_Earthquake_CrackMode = null;
             UI_Earthquake_EvacuationMode = null;
             UI_MeteorStrike_Enabled = null;
@@ -940,6 +949,7 @@ namespace NaturalDisastersRenewal.UI
             disasterContainer.Thunderstorm.SetRealTimeThunderstormFrequency(frequency);
             disasterContainer.Sinkhole.SetRealTimeSinkholeFrequency(frequency);
             disasterContainer.Tornado.SetRealTimeTornadoFrequency(frequency);
+            disasterContainer.Earthquake.SetRealTimeEarthquakeFrequency(frequency);
             disasterContainer.MeteorStrike.SetRealTimeMeteorFrequency(frequency);
         }
 
@@ -997,6 +1007,14 @@ namespace NaturalDisastersRenewal.UI
                 disasterContainer.Tornado.GetRealTimeTornadoFrequencySelectionIndex(),
                 disasterContainer.Tornado.RealTimeTornadoFrequency != disasterContainer.RealTimeFrequencyHarmony,
                 disasterContainer.Tornado.GetRealTimeTornadoFrequencyTooltip());
+
+            SetFrequencyDropdownWarning(
+                UI_Earthquake_RealTimeFrequency,
+                UI_Earthquake_RealTimeFrequencyWarning,
+                EarthquakeModel.GetRealTimeEarthquakeFrequencyOptions(),
+                disasterContainer.Earthquake.GetRealTimeEarthquakeFrequencySelectionIndex(),
+                disasterContainer.Earthquake.RealTimeEarthquakeFrequency != disasterContainer.RealTimeFrequencyHarmony,
+                disasterContainer.Earthquake.GetRealTimeEarthquakeFrequencyTooltip());
 
             SetFrequencyDropdownWarning(
                 UI_MeteorStrike_RealTimeFrequency,
@@ -1627,6 +1645,32 @@ namespace NaturalDisastersRenewal.UI
                 LocalizationService.Get("settings.enable_aftershocks.tooltip"));
 
             DropDownHelper.AddDropDown(
+                ref UI_Earthquake_RealTimeFrequency,
+                ref earthquakeGroup,
+                LocalizationService.Get("settings.earthquake.realtime_frequency"),
+                EarthquakeModel.GetRealTimeEarthquakeFrequencyOptions(),
+                ref disasterContainer.Earthquake.RealTimeEarthquakeFrequency,
+                delegate(int selection)
+                {
+                    if (!_freezeUI)
+                    {
+                        disasterContainer.Earthquake.SetRealTimeEarthquakeFrequency(
+                            EarthquakeModel.GetRealTimeEarthquakeFrequencyFromSelection(selection));
+                        UI_Earthquake_RealTimeFrequency.tooltip =
+                            disasterContainer.Earthquake.GetRealTimeEarthquakeFrequencyTooltip();
+                        RefreshRealTimeFrequencyHarmonyWarnings(disasterContainer);
+                    }
+                });
+            UI_Earthquake_RealTimeFrequency.selectedIndex =
+                disasterContainer.Earthquake.GetRealTimeEarthquakeFrequencySelectionIndex();
+            UI_Earthquake_RealTimeFrequency.tooltip =
+                disasterContainer.Earthquake.GetRealTimeEarthquakeFrequencyTooltip();
+            UI_Earthquake_RealTimeFrequencyWarning =
+                CreateFrequencyWarningIcon(UI_Earthquake_RealTimeFrequency);
+            SetEarthquakeRealTimeControlsAvailability(disasterContainer.Earthquake.IsRealTimePatternActive());
+            RefreshRealTimeFrequencyHarmonyWarnings(disasterContainer);
+
+            DropDownHelper.AddDropDown(
                 ref UI_Earthquake_CrackMode,
                 ref earthquakeGroup,
                 LocalizationService.Get("settings.ground_cracks"),
@@ -1666,6 +1710,18 @@ namespace NaturalDisastersRenewal.UI
             );
 
             helper.AddSpacing(20);
+        }
+
+        private void SetEarthquakeRealTimeControlsAvailability(bool realTimeActive)
+        {
+            if (UI_Earthquake_MaxProbability != null)
+                UI_Earthquake_MaxProbability.isEnabled = !realTimeActive;
+
+            if (UI_Earthquake_WarmupYears != null)
+                UI_Earthquake_WarmupYears.isEnabled = !realTimeActive;
+
+            if (UI_Earthquake_RealTimeFrequency != null)
+                UI_Earthquake_RealTimeFrequency.isEnabled = realTimeActive;
         }
 
         private void SetupMeteorStrike(ref UIHelper helper, DisasterSetupModel disasterContainer)


### PR DESCRIPTION
This pull request introduces a new debug feature to manually set disaster progress for testing, adds extensive localization for new and existing earthquake-related settings and tooltips (in both English and Spanish), and improves disaster models to support debug progress overrides. It also updates earthquake serialization to include new real-time scheduling fields.

**Debug disaster progress feature:**

* Added new debug-only methods and fields to `DisasterBaseModel` and its derived classes, allowing manual override of disaster progress for testing purposes. This includes the ability to force an immediate disaster occurrence and to set progress via a debug UI. [[1]](diffhunk://#diff-6569db19ae9a0f12bc82c3d6183dad82c58ed5101e1106844a3a70c058541fdeR26-R27) [[2]](diffhunk://#diff-6569db19ae9a0f12bc82c3d6183dad82c58ed5101e1106844a3a70c058541fdeR69-R71) [[3]](diffhunk://#diff-6569db19ae9a0f12bc82c3d6183dad82c58ed5101e1106844a3a70c058541fdeR203-R222) [[4]](diffhunk://#diff-6569db19ae9a0f12bc82c3d6183dad82c58ed5101e1106844a3a70c058541fdeR547-R549) [[5]](diffhunk://#diff-de10b9d3e159bd3fefc8455c45f9ee5ae9e8524d0f8e5bbe0b6a1eddc47dc848R598-R616) [[6]](diffhunk://#diff-9458739662851227a2da3e5a1db6b7bd9d5ba122d07c4944ab5a9ec6065bc409R272-R293) [[7]](diffhunk://#diff-0f379b4cfd6206be77f3c7290b4a60a473f6b29e07fa5cbc8ab955472b41bfbfR876-R889) [[8]](diffhunk://#diff-38c0c635042440c6d97ae2ac654578089d6bfa3678f0c036a449848592e81604R354-R367) [[9]](diffhunk://#diff-8cd842fd51a53a99db4f49c0f3540b84e9ddfc03d749dbfb4d726ada20395e41R470-R481)

* Added corresponding localization strings for the debug disaster progress controls and tooltips in both English and Spanish. [[1]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faR147-R157) [[2]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faR636-R646)

**Earthquake and real-time disaster improvements:**

* Expanded localization for earthquake frequency settings, real-time scheduling, and tooltips, including new frequency options and improved descriptions in both languages. [[1]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faL295-R333) [[2]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faR462-R474) [[3]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faL742-R822) [[4]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faR948-R960)

* Improved aftershock and warmup tooltips for clarity and accuracy in both English and Spanish. [[1]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faL295-R333) [[2]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faL742-R822)

**Serialization updates:**

* Updated earthquake serialization/deserialization logic to store and retrieve new real-time scheduling fields, ensuring proper save/load of real-time earthquake state. [[1]](diffhunk://#diff-e8b9a68199ddbc97c410985add37ce1459df22efd3851092e7cd56b88062bdaeR30-R35) [[2]](diffhunk://#diff-e8b9a68199ddbc97c410985add37ce1459df22efd3851092e7cd56b88062bdaeR59-R68)