### PR TITLE
Refactor 018/12 real time compatibility for tsunamis

### DIFF
--- a/Source/Common/LocalizationService.cs
+++ b/Source/Common/LocalizationService.cs
@@ -297,8 +297,30 @@ namespace NaturalDisastersRenewal.Common
                         },
                         {
                             "settings.tsunami.warmup.tooltip",
-                            "The probability of tsunami increases to the maximum during this period."
+                            "The probability of tsunami increases to the maximum during this period when Real Time is inactive."
                         },
+                        {
+                            "settings.tsunami.realtime_frequency",
+                            "Real Time tsunami frequency"
+                        },
+                        {
+                            "settings.tsunami.realtime_frequency.tooltip.selected",
+                            "Chooses the random real-time ocean interval used between automatic tsunamis while Real Time is active.\nSelected reference period: {0}."
+                        },
+                        { "settings.tsunami.frequency.apocalypse", "Apocalypse: 2-4 hours" },
+                        { "settings.tsunami.frequency.frequent", "Frequent: 4-8 hours" },
+                        { "settings.tsunami.frequency.occasional", "Occasional: 8-16 hours" },
+                        { "settings.tsunami.frequency.uncommon", "Uncommon: 16-32 hours" },
+                        { "settings.tsunami.frequency.rare", "Rare: 32-64 hours" },
+                        { "settings.tsunami.frequency_name.apocalypse", "Apocalypse" },
+                        { "settings.tsunami.frequency_name.frequent", "Frequent" },
+                        { "settings.tsunami.frequency_name.occasional", "Occasional" },
+                        { "settings.tsunami.frequency_name.uncommon", "Uncommon" },
+                        { "settings.tsunami.frequency_name.rare", "Rare" },
+                        { "tooltip.tsunami.realtime_active", "Real Time active: tsunami charge period uses real-time intervals." },
+                        { "tooltip.tsunami.realtime_reference", "Selected reference period: {0}" },
+                        { "tooltip.tsunami.current_tsunami_interval", "Current ocean interval: {0}" },
+                        { "tooltip.tsunami.tsunami_time_remaining", "Time remaining: {0}" },
                         { "settings.warmup_period", "Warmup period" },
                         { "settings.warmup_period.days", " days" },
                         {
@@ -786,8 +808,30 @@ namespace NaturalDisastersRenewal.Common
                         },
                         {
                             "settings.tsunami.warmup.tooltip",
-                            "La probabilidad del tsunami aumenta al maximo durante este periodo."
+                            "La probabilidad del tsunami aumenta al maximo durante este periodo cuando Real Time no esta activo."
                         },
+                        {
+                            "settings.tsunami.realtime_frequency",
+                            "Frecuencia de tsunamis con Real Time"
+                        },
+                        {
+                            "settings.tsunami.realtime_frequency.tooltip.selected",
+                            "Elige el intervalo oceanico aleatorio en tiempo real entre tsunamis automaticos mientras Real Time esta activo.\nPeriodo de referencia seleccionado: {0}."
+                        },
+                        { "settings.tsunami.frequency.apocalypse", "Apocalipsis: 2-4 horas" },
+                        { "settings.tsunami.frequency.frequent", "Frecuente: 4-8 horas" },
+                        { "settings.tsunami.frequency.occasional", "Ocasional: 8-16 horas" },
+                        { "settings.tsunami.frequency.uncommon", "Poco frecuente: 16-32 horas" },
+                        { "settings.tsunami.frequency.rare", "Raro: 32-64 horas" },
+                        { "settings.tsunami.frequency_name.apocalypse", "Apocalipsis" },
+                        { "settings.tsunami.frequency_name.frequent", "Frecuente" },
+                        { "settings.tsunami.frequency_name.occasional", "Ocasional" },
+                        { "settings.tsunami.frequency_name.uncommon", "Poco frecuente" },
+                        { "settings.tsunami.frequency_name.rare", "Raro" },
+                        { "tooltip.tsunami.realtime_active", "Real Time activo: el periodo de carga de tsunamis usa intervalos en tiempo real." },
+                        { "tooltip.tsunami.realtime_reference", "Periodo de referencia seleccionado: {0}" },
+                        { "tooltip.tsunami.current_tsunami_interval", "Intervalo oceanico actual: {0}" },
+                        { "tooltip.tsunami.tsunami_time_remaining", "Tiempo restante: {0}" },
                         { "settings.warmup_period", "Periodo de calentamiento" },
                         { "settings.warmup_period.days", " dias" },
                         {

--- a/Source/Models/NaturalDisaster/DisasterBaseModel.cs
+++ b/Source/Models/NaturalDisaster/DisasterBaseModel.cs
@@ -741,7 +741,7 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             manualReleaseDisasters.Add(disasterId);
         }
 
-        private void SetupAutomaticFocusedEvacuation(DisasterInfoModel disasterInfoModel, float disasterRadius,
+        protected virtual void SetupAutomaticFocusedEvacuation(DisasterInfoModel disasterInfoModel, float disasterRadius,
             ref List<DisasterInfoModel> activeDisasters)
         {
             var disasterTargetPosition = new Vector3(disasterInfoModel.DisasterInfo.targetX,

--- a/Source/Models/NaturalDisaster/TsunamiModel.cs
+++ b/Source/Models/NaturalDisaster/TsunamiModel.cs
@@ -18,6 +18,9 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
         private const float CurrentWaveBandLength = 3000f;
         private const float MinFutureEvacuationDistance = 6000f;
         private const float MaxFutureEvacuationDistance = 16000f;
+        private const float MinCoastalWaterSearchRadius = 768f;
+        private const float MaxCoastalWaterSearchRadius = 1920f;
+        private const float MaxCoastalElevationAboveWater = 80f;
         private const string ExtendedInfoPanel2ModKey = "extendedInfoPanel2";
 
         private static readonly RealTimeDisasterFrequencyPreset[] RealTimeTsunamiFrequencyOptionValues =
@@ -243,7 +246,10 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             if (CanAffectAt(disasterId, ref disasterData, shelterPosition, disasterTargetPosition, out priority))
                 return true;
 
-            return CanTsunamiReachShelterLater(ref disasterData, shelterPosition, disasterTargetPosition, out priority);
+            if (CanTsunamiReachShelterLater(ref disasterData, shelterPosition, disasterTargetPosition, out priority))
+                return true;
+
+            return IsCoastalShelterAtRisk(shelterPosition, disasterData.m_intensity, out priority);
         }
 
         public override bool CheckDisasterAIType(object disasterAI)
@@ -323,6 +329,41 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
                 MinFutureEvacuationDistance,
                 MaxFutureEvacuationDistance,
                 Mathf.Clamp01(intensity / 255f));
+        }
+
+        private static bool IsCoastalShelterAtRisk(Vector3 shelterPosition, byte intensity, out float priority)
+        {
+            priority = 0f;
+
+            var terrain = Services.Terrain;
+            if (terrain == null)
+                return false;
+
+            var terrainHeight = terrain.SampleRawHeightSmooth(shelterPosition);
+            var waterSurfaceHeight = terrain.SampleRawHeightSmoothWithWater(shelterPosition, false, 0f);
+            var waterDepthAtShelter = waterSurfaceHeight - terrainHeight;
+            if (waterDepthAtShelter > 0f)
+            {
+                priority = 1f;
+                return true;
+            }
+
+            var searchRadius = Mathf.Lerp(
+                MinCoastalWaterSearchRadius,
+                MaxCoastalWaterSearchRadius,
+                Mathf.Clamp01(intensity / 255f));
+            var waterDistance = terrain.CalculateWaterProximity(shelterPosition, searchRadius, out waterSurfaceHeight);
+            if (waterDistance >= searchRadius)
+                return false;
+
+            var elevationAboveWater = terrainHeight - waterSurfaceHeight;
+            if (elevationAboveWater > MaxCoastalElevationAboveWater)
+                return false;
+
+            var distanceFactor = Mathf.Clamp01(1f - waterDistance / searchRadius);
+            var elevationFactor = Mathf.Clamp01(1f - Mathf.Max(0f, elevationAboveWater) / MaxCoastalElevationAboveWater);
+            priority = Mathf.Clamp01(Mathf.Max(0.25f, distanceFactor * elevationFactor));
+            return true;
         }
 
         public bool IsRealTimePatternActive()

--- a/Source/Models/NaturalDisaster/TsunamiModel.cs
+++ b/Source/Models/NaturalDisaster/TsunamiModel.cs
@@ -1,21 +1,41 @@
-using ColossalFramework;
+using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
 using ICities;
 using NaturalDisastersRenewal.Common;
 using NaturalDisastersRenewal.Common.enums;
-using NaturalDisastersRenewal.Common.Types;
 using NaturalDisastersRenewal.Handlers;
 using NaturalDisastersRenewal.Models.Disaster;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
-using static ColossalFramework.DataBinding.BindPropertyByKey;
-using static RenderManager;
 
 namespace NaturalDisastersRenewal.Models.NaturalDisaster
 {
     public class TsunamiModel : DisasterBaseModel
     {
+        private const float GuaranteedOccurrencePerFrame = 1f;
+        private const float SecondsPerMinute = 60f;
+        private const float MaxRealTimeDeltaSeconds = 5f;
+        private const float CurrentWaveBandLength = 3000f;
+        private const float MinFutureEvacuationDistance = 6000f;
+        private const float MaxFutureEvacuationDistance = 16000f;
+        private const string ExtendedInfoPanel2ModKey = "extendedInfoPanel2";
+
+        private static readonly RealTimeDisasterFrequencyPreset[] RealTimeTsunamiFrequencyOptionValues =
+        {
+            RealTimeDisasterFrequencyPreset.Apocalypse,
+            RealTimeDisasterFrequencyPreset.Frequent,
+            RealTimeDisasterFrequencyPreset.Occasional,
+            RealTimeDisasterFrequencyPreset.Uncommon,
+            RealTimeDisasterFrequencyPreset.Rare
+        };
+
+        [XmlIgnore] private float _lastRealTimeScheduleUpdateSeconds = -1f;
+        [XmlIgnore] public float RealTimeCurrentTsunamiPeriodMinutes = -1f;
+        [XmlIgnore] public float RealTimeMinutesUntilNextTsunami = -1f;
+
+        public RealTimeDisasterFrequencyPreset RealTimeTsunamiFrequency =
+            RealTimeDisasterFrequencyPreset.Occasional;
+
         public TsunamiModel()
         {
             DType = DisasterType.Tsunami;
@@ -26,10 +46,7 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
 
         public float WarmupYears
         {
-            get
-            {
-                return probabilityWarmupDays / 360f;
-            }
+            get { return probabilityWarmupDays / 360f; }
 
             set
             {
@@ -39,13 +56,47 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             }
         }
 
-        public override void OnDisasterActivated(DisasterSettings disasterInfo, ushort disasterId, ref List<DisasterInfoModel> activeDisasters)
+        protected override void OnSimulationFrameLocal()
+        {
+            if (IsRealTimePatternActive())
+                UpdateRealTimeTsunamiSchedule();
+        }
+
+        protected override float GetCurrentOccurrencePerYearLocal()
+        {
+            if (IsRealTimePatternActive())
+                return IsRealTimeTsunamiDue()
+                    ? 365f / GetSimulationDaysPerFrame() * GuaranteedOccurrencePerFrame
+                    : 0f;
+
+            return IsTsunamiCharged()
+                ? 365f / GetSimulationDaysPerFrame() * GuaranteedOccurrencePerFrame
+                : 0f;
+        }
+
+        protected override float GetSimulationDaysPerFrame()
+        {
+            return IsRealTimePatternActive()
+                ? DisasterSimulationUtils.VanillaSimulationDaysPerFrame
+                : base.GetSimulationDaysPerFrame();
+        }
+
+        public override byte GetMaximumIntensity()
+        {
+            return IsRealTimePatternActive()
+                ? ScaleIntensityByPopulation(baseIntensity)
+                : base.GetMaximumIntensity();
+        }
+
+        public override void OnDisasterActivated(DisasterSettings disasterInfo, ushort disasterId,
+            ref List<DisasterInfoModel> activeDisasters)
         {
             disasterInfo.type |= DisasterType.Tsunami;
             base.OnDisasterActivated(disasterInfo, disasterId, ref activeDisasters);
         }
 
-        public override void OnDisasterDeactivated(DisasterInfoModel disasterInfoUnified, ref List<DisasterInfoModel> activeDisasters)
+        public override void OnDisasterDeactivated(DisasterInfoModel disasterInfoUnified,
+            ref List<DisasterInfoModel> activeDisasters)
         {
             disasterInfoUnified.DisasterInfo.type |= DisasterType.Tsunami;
             disasterInfoUnified.EvacuationMode = EvacuationMode;
@@ -53,13 +104,11 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             disasterInfoUnified.IgnoreDestructionZone = true;
 
             if (!IsEvacuating())
-            {
                 base.OnDisasterDeactivated(disasterInfoUnified, ref activeDisasters);
-            }
-
         }
 
-        public override void OnDisasterDetected(DisasterInfoModel disasterInfoUnified, ref List<DisasterInfoModel> activeDisasters)
+        public override void OnDisasterDetected(DisasterInfoModel disasterInfoUnified,
+            ref List<DisasterInfoModel> activeDisasters)
         {
             disasterInfoUnified.DisasterInfo.type |= DisasterType.Tsunami;
             disasterInfoUnified.EvacuationMode = EvacuationMode;
@@ -69,7 +118,8 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             base.OnDisasterDetected(disasterInfoUnified, ref activeDisasters);
         }
 
-        public override void OnDisasterFinished(DisasterInfoModel disasterInfoUnified, ref List<DisasterInfoModel> activeDisasters)
+        public override void OnDisasterFinished(DisasterInfoModel disasterInfoUnified,
+            ref List<DisasterInfoModel> activeDisasters)
         {
             disasterInfoUnified.DisasterInfo.type |= DisasterType.Tsunami;
             disasterInfoUnified.EvacuationMode = EvacuationMode;
@@ -79,39 +129,121 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
             base.OnDisasterDeactivated(disasterInfoUnified, ref activeDisasters);
         }
 
-        public override void SetupAutomaticEvacuation(DisasterInfoModel disasterInfoModel, ref List<DisasterInfoModel> activeDisasters)
+        public override void OnDisasterStarted(byte intensity)
         {
-            //Get disaster Info
-            DisasterInfo disasterInfo = NaturalDisasterHandler.GetDisasterInfo(DType);
+            if (IsRealTimePatternActive())
+            {
+                ResetRealTimeSchedule();
+                ClearRealTimeCooldownState();
+                return;
+            }
 
-            if (disasterInfo == null)
+            base.OnDisasterStarted(intensity);
+        }
+
+        public override string GetProbabilityTooltip(float value)
+        {
+            if (IsRealTimePatternActive() && calmDaysLeft <= 0)
+                return GetRealTimeProbabilityTooltip(value);
+
+            return base.GetProbabilityTooltip(value);
+        }
+
+        public override void SetupAutomaticEvacuation(DisasterInfoModel disasterInfoModel,
+            ref List<DisasterInfoModel> activeDisasters)
+        {
+            SetupTsunamiEvacuation(disasterInfoModel, null, ref activeDisasters);
+        }
+
+        protected override void SetupAutomaticFocusedEvacuation(DisasterInfoModel disasterInfoModel,
+            float disasterRadius, ref List<DisasterInfoModel> activeDisasters)
+        {
+            SetupTsunamiEvacuation(disasterInfoModel, disasterRadius, ref activeDisasters);
+        }
+
+        private void SetupTsunamiEvacuation(DisasterInfoModel disasterInfoModel, float? focusedRadius,
+            ref List<DisasterInfoModel> activeDisasters)
+        {
+            if (NaturalDisasterHandler.GetDisasterInfo(DType) == null)
                 return;
 
-            //Identify Shelters
-            BuildingManager buildingManager = Services.Buildings;
-            FastList<ushort> serviceBuildings = buildingManager.GetServiceBuildings(ItemClass.Service.Disaster);
+            var disasterTargetPosition = new Vector3(
+                disasterInfoModel.DisasterInfo.targetX,
+                disasterInfoModel.DisasterInfo.targetY,
+                disasterInfoModel.DisasterInfo.targetZ);
 
+            var buildingManager = Services.Buildings;
+            var serviceBuildings = buildingManager.GetServiceBuildings(ItemClass.Service.Disaster);
             if (serviceBuildings == null)
                 return;
 
-            //Release all shelters but Potentyally destroyed
-            for (int i = 0; i < serviceBuildings.m_size; i++)
-            {
-                ushort num = serviceBuildings.m_buffer[i];
-                if (num != 0)
-                {
-                    //here we got all shelter buildings
-                    var buildingInfo = buildingManager.m_buildings.m_buffer[num];
+            var focusedEvacuationRadius = focusedRadius.HasValue ? (float)Math.Sqrt(focusedRadius.Value) : 0f;
 
-                    if ((buildingInfo.Info.m_buildingAI as ShelterAI) != null)
-                    {
-                            disasterInfoModel.ShelterList.Add(num);
-                            SetBuidingEvacuationStatus(buildingInfo.Info.m_buildingAI as ShelterAI, num, ref buildingManager.m_buildings.m_buffer[num], false);
-                    }
-                }
+            for (var i = 0; i < serviceBuildings.m_size; i++)
+            {
+                var shelterId = serviceBuildings.m_buffer[i];
+                if (shelterId == 0)
+                    continue;
+
+                var buildingInfo = buildingManager.m_buildings.m_buffer[shelterId];
+                if (buildingInfo.Info == null)
+                    continue;
+
+                var shelterAI = buildingInfo.Info.m_buildingAI as ShelterAI;
+                if (shelterAI == null)
+                    continue;
+
+                var shelterPosition = buildingInfo.m_position;
+                float priority;
+                if (!CanTsunamiAffectShelter(disasterInfoModel.DisasterId, shelterPosition, disasterTargetPosition,
+                        out priority))
+                    continue;
+
+                float shelterRadius =
+                    (buildingInfo.Length < buildingInfo.Width ? buildingInfo.Width : buildingInfo.Length) * 8 / 2f;
+
+                if (focusedRadius.HasValue &&
+                    !IsShelterInDisasterZone(disasterTargetPosition, shelterPosition, shelterRadius,
+                        focusedEvacuationRadius))
+                    continue;
+
+                disasterInfoModel.ShelterList.Add(shelterId);
+                SetBuidingEvacuationStatus(shelterAI, shelterId, ref buildingManager.m_buildings.m_buffer[shelterId],
+                    false);
+
+                DebugLogger.Log(string.Format(
+                    "Tsunami evacuation enabled for shelter {0}. DisasterId: {1}, Priority: {2:0.000}, Focused: {3}",
+                    shelterId,
+                    disasterInfoModel.DisasterId,
+                    priority,
+                    focusedRadius.HasValue));
+            }
+
+            if (disasterInfoModel.ShelterList.Count == 0)
+            {
+                DebugLogger.Log(string.Format(
+                    "No shelters found inside tsunami affectation range. DisasterId: {0}",
+                    disasterInfoModel.DisasterId));
+                return;
             }
 
             AddOrReplaceActiveDisaster(disasterInfoModel, ref activeDisasters);
+        }
+
+        private bool CanTsunamiAffectShelter(ushort disasterId, Vector3 shelterPosition,
+            Vector3 disasterTargetPosition, out float priority)
+        {
+            priority = 0f;
+
+            var disasterManager = Services.Disasters;
+            if (disasterManager == null || disasterId >= disasterManager.m_disasters.m_buffer.Length)
+                return false;
+
+            var disasterData = disasterManager.m_disasters.m_buffer[disasterId];
+            if (CanAffectAt(disasterId, ref disasterData, shelterPosition, disasterTargetPosition, out priority))
+                return true;
+
+            return CanTsunamiReachShelterLater(ref disasterData, shelterPosition, disasterTargetPosition, out priority);
         }
 
         public override bool CheckDisasterAIType(object disasterAI)
@@ -128,41 +260,342 @@ namespace NaturalDisastersRenewal.Models.NaturalDisaster
         {
             base.CopySettings(disaster);
 
-            TsunamiModel d = disaster as TsunamiModel;
-            if (d != null)
+            var tsunami = disaster as TsunamiModel;
+            if (tsunami != null)
             {
-                WarmupYears = d.WarmupYears;
+                WarmupYears = tsunami.WarmupYears;
+                SetRealTimeTsunamiFrequency(tsunami.RealTimeTsunamiFrequency);
             }
         }
 
-        public override bool CanAffectAt(ushort disasterID, ref DisasterData disasterData, Vector3 buildingPosition, Vector3 closestShelter, out float priority)
+        public override bool CanAffectAt(ushort disasterID, ref DisasterData disasterData,
+            Vector3 buildingPosition, Vector3 closestShelter, out float priority)
         {
-            string nl = $"{Environment.NewLine}";
-            DebugLogger.Log($"DisasterId: {disasterID}");
-
-            bool itCanAffect = base.CanAffectAt(disasterID, ref disasterData, buildingPosition, new Vector3(), out priority);
+            var itCanAffect = base.CanAffectAt(disasterID, ref disasterData, buildingPosition, new Vector3(),
+                out priority);
             if (!itCanAffect)
-            {
                 return false;
-            }
+
             var simulationFrame = Services.Simulation.m_currentFrameIndex;
             var disasterStartFrame = disasterData.m_startFrame;
 
             var dot1 = 0f - Mathf.Sin(disasterData.m_angle);
-            var dot2 = 0f;
             var dot3 = Mathf.Cos(disasterData.m_angle);
-            Vector3 rhsVector = new Vector3(dot1, dot2, dot3);
-            Vector3 lhsVector = buildingPosition - closestShelter;
+            var rhsVector = new Vector3(dot1, 0f, dot3);
+            var lhsVector = buildingPosition - closestShelter;
 
-            //DOT => lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z
-            float num = Vector3.Dot(lhsVector, rhsVector);
-            uint num2 = simulationFrame - disasterStartFrame;
-            float num3 = (float)num2 * 0.125f - 3000f;
-            float num4 = (float)num2 * 0.125f;
+            var num = Vector3.Dot(lhsVector, rhsVector);
+            var num2 = simulationFrame - disasterStartFrame;
+            var num3 = num2 * 0.125f - 3000f;
+            var num4 = num2 * 0.125f;
             priority = Mathf.Clamp01(Mathf.Min((num4 - num) * 0.01f, (num - num3) * 0.0005f));
-            bool calculation = num >= num3 && num <= num4;
+            return num >= num3 && num <= num4;
+        }
 
-            return calculation;
+        private bool CanTsunamiReachShelterLater(ref DisasterData disasterData, Vector3 shelterPosition,
+            Vector3 disasterTargetPosition, out float priority)
+        {
+            priority = 0f;
+
+            if ((disasterData.m_flags &
+                 (DisasterData.Flags.Emerging | DisasterData.Flags.Active | DisasterData.Flags.Clearing)) == 0)
+                return false;
+
+            var waveDirection = GetTsunamiWaveDirection(disasterData.m_angle);
+            var projectedDistance = Vector3.Dot(shelterPosition - disasterTargetPosition, waveDirection);
+            var futureReachDistance = GetFutureEvacuationDistance(disasterData.m_intensity);
+
+            if (projectedDistance < -CurrentWaveBandLength || projectedDistance > futureReachDistance)
+                return false;
+
+            priority = Mathf.Clamp01(1f - Mathf.Max(0f, projectedDistance) / futureReachDistance);
+            return true;
+        }
+
+        private static Vector3 GetTsunamiWaveDirection(float angle)
+        {
+            return new Vector3(0f - Mathf.Sin(angle), 0f, Mathf.Cos(angle));
+        }
+
+        private static float GetFutureEvacuationDistance(byte intensity)
+        {
+            return Mathf.Lerp(
+                MinFutureEvacuationDistance,
+                MaxFutureEvacuationDistance,
+                Mathf.Clamp01(intensity / 255f));
+        }
+
+        public bool IsRealTimePatternActive()
+        {
+            return DisasterSimulationUtils.IsRealTimeModActive();
+        }
+
+        public override void OnEnabledChanged(bool enabled)
+        {
+            _lastRealTimeScheduleUpdateSeconds = Time.realtimeSinceStartup;
+        }
+
+        public float GetProbabilityProgress()
+        {
+            if (IsRealTimePatternActive())
+                return GetRealTimePatternProbabilityProgress();
+
+            if (calmDaysLeft > 0)
+                return 0f;
+
+            if (probabilityWarmupDays <= 0 || probabilityWarmupDaysLeft <= 0f)
+                return 1f;
+
+            return Mathf.Clamp01(1f - probabilityWarmupDaysLeft / probabilityWarmupDays);
+        }
+
+        private bool IsTsunamiCharged()
+        {
+            return probabilityWarmupDays <= 0 || probabilityWarmupDaysLeft <= 0f;
+        }
+
+        public float GetRealTimePatternProbabilityProgress()
+        {
+            EnsureRealTimeSchedule();
+            return Mathf.Clamp01(1f - RealTimeMinutesUntilNextTsunami / RealTimeCurrentTsunamiPeriodMinutes);
+        }
+
+        private string GetRealTimeProbabilityTooltip(float probabilityValue)
+        {
+            if (!unlocked) return LocalizationService.Get("tooltip.not_unlocked");
+
+            EnsureRealTimeSchedule();
+            return string.Format(
+                "{0}: {1}{2}{3}{2}{4}{2}{5}{2}{6}",
+                LocalizationService.Get("tooltip.progress"),
+                string.Format("{0:00.00}%", probabilityValue * 100),
+                CommonProperties.NewLine,
+                LocalizationService.Get("tooltip.tsunami.realtime_active"),
+                LocalizationService.Format("tooltip.tsunami.realtime_reference", GetRealTimeTsunamiFrequencyName()),
+                LocalizationService.Format(
+                    "tooltip.tsunami.current_tsunami_interval",
+                    DisasterSimulationUtils.FormatRealTimeMinutes(RealTimeCurrentTsunamiPeriodMinutes)),
+                LocalizationService.Format(
+                    "tooltip.tsunami.tsunami_time_remaining",
+                    DisasterSimulationUtils.FormatRealTimeMinutes(RealTimeMinutesUntilNextTsunami)));
+        }
+
+        private void UpdateRealTimeTsunamiSchedule()
+        {
+            EnsureRealTimeSchedule();
+
+            RealTimeMinutesUntilNextTsunami = Mathf.Max(
+                0f,
+                RealTimeMinutesUntilNextTsunami - GetRealTimeElapsedMinutes());
+
+            ClearRealTimeCooldownState();
+        }
+
+        private bool IsRealTimeTsunamiDue()
+        {
+            EnsureRealTimeSchedule();
+            return RealTimeMinutesUntilNextTsunami <= 0f;
+        }
+
+        private void EnsureRealTimeSchedule()
+        {
+            if (RealTimeCurrentTsunamiPeriodMinutes <= 0f || RealTimeMinutesUntilNextTsunami < 0f)
+                ScheduleNextRealTimeTsunami();
+
+            if (RealTimeMinutesUntilNextTsunami > RealTimeCurrentTsunamiPeriodMinutes)
+                RealTimeMinutesUntilNextTsunami = RealTimeCurrentTsunamiPeriodMinutes;
+        }
+
+        private void ResetRealTimeSchedule()
+        {
+            ScheduleNextRealTimeTsunami();
+        }
+
+        private void ScheduleNextRealTimeTsunami()
+        {
+            ScheduleNextRealTimeTsunami(0f);
+        }
+
+        private void ScheduleNextRealTimeTsunami(float progressToKeep)
+        {
+            var progress = Mathf.Clamp01(progressToKeep);
+            RealTimeCurrentTsunamiPeriodMinutes = GetRandomRealTimeIntervalMinutes();
+            RealTimeMinutesUntilNextTsunami = RealTimeCurrentTsunamiPeriodMinutes * (1f - progress);
+            _lastRealTimeScheduleUpdateSeconds = Time.realtimeSinceStartup;
+        }
+
+        private void ClearRealTimeCooldownState()
+        {
+            calmDaysLeft = 0f;
+            probabilityWarmupDaysLeft = 0f;
+            intensityWarmupDaysLeft = 0f;
+        }
+
+        private float GetRealTimeElapsedMinutes()
+        {
+            var currentSeconds = Time.realtimeSinceStartup;
+
+            if (_lastRealTimeScheduleUpdateSeconds < 0f)
+            {
+                _lastRealTimeScheduleUpdateSeconds = currentSeconds;
+                return 0f;
+            }
+
+            var elapsedSeconds = Mathf.Clamp(
+                currentSeconds - _lastRealTimeScheduleUpdateSeconds,
+                0f,
+                MaxRealTimeDeltaSeconds);
+            _lastRealTimeScheduleUpdateSeconds = currentSeconds;
+            return elapsedSeconds / SecondsPerMinute * GetRealTimeSpeedFactor();
+        }
+
+        private static float GetRealTimeSpeedFactor()
+        {
+            var simulation = Services.Simulation;
+            if (simulation == null || simulation.SimulationPaused)
+                return 0f;
+
+            var speed = Mathf.Max(1, simulation.FinalSimulationSpeed);
+            if (ModCompatibilityService.IsActive(ExtendedInfoPanel2ModKey))
+                return GetExtendedInfoPanelSpeedFactor(speed);
+
+            return GetVanillaSpeedFactor(speed);
+        }
+
+        private static float GetVanillaSpeedFactor(int speed)
+        {
+            if (speed <= 1)
+                return 1f;
+
+            return speed == 2 ? 1.5f : 2f;
+        }
+
+        private static float GetExtendedInfoPanelSpeedFactor(int speed)
+        {
+            if (speed <= 3)
+                return GetVanillaSpeedFactor(speed);
+
+            switch (speed)
+            {
+                case 4:
+                    return 2.5f;
+                case 5:
+                    return 3f;
+                default:
+                    return 3.5f;
+            }
+        }
+
+        private float GetRandomRealTimeIntervalMinutes()
+        {
+            GetRealTimeIntervalRange(out var minMinutes, out var maxMinutes);
+
+            var randomValue = Services.Simulation.m_randomizer.Int32(0, 10000) / 10000f;
+            return minMinutes + (maxMinutes - minMinutes) * randomValue;
+        }
+
+        private void GetRealTimeIntervalRange(out float minMinutes, out float maxMinutes)
+        {
+            switch (RealTimeTsunamiFrequency)
+            {
+                case RealTimeDisasterFrequencyPreset.Apocalypse:
+                    minMinutes = 120f;
+                    maxMinutes = 240f;
+                    break;
+                case RealTimeDisasterFrequencyPreset.Frequent:
+                    minMinutes = 240f;
+                    maxMinutes = 480f;
+                    break;
+                case RealTimeDisasterFrequencyPreset.Occasional:
+                default:
+                    minMinutes = 480f;
+                    maxMinutes = 960f;
+                    break;
+                case RealTimeDisasterFrequencyPreset.Uncommon:
+                    minMinutes = 960f;
+                    maxMinutes = 1920f;
+                    break;
+                case RealTimeDisasterFrequencyPreset.Rare:
+                    minMinutes = 1920f;
+                    maxMinutes = 3840f;
+                    break;
+            }
+        }
+
+        public void SetRealTimeTsunamiFrequency(RealTimeDisasterFrequencyPreset frequency)
+        {
+            if (RealTimeTsunamiFrequency == frequency)
+                return;
+
+            var currentProgress = GetRealTimePatternProbabilityProgress();
+            RealTimeTsunamiFrequency = frequency;
+            ScheduleNextRealTimeTsunami(currentProgress);
+        }
+
+        public override void SetDebugProbabilityProgress(float progress)
+        {
+            base.SetDebugProbabilityProgress(progress);
+
+            if (IsRealTimePatternActive())
+            {
+                ScheduleNextRealTimeTsunami(progress);
+                ClearRealTimeCooldownState();
+            }
+        }
+
+        public static string[] GetRealTimeTsunamiFrequencyOptions()
+        {
+            return new[]
+            {
+                LocalizationService.Get("settings.tsunami.frequency.apocalypse"),
+                LocalizationService.Get("settings.tsunami.frequency.frequent"),
+                LocalizationService.Get("settings.tsunami.frequency.occasional"),
+                LocalizationService.Get("settings.tsunami.frequency.uncommon"),
+                LocalizationService.Get("settings.tsunami.frequency.rare")
+            };
+        }
+
+        public int GetRealTimeTsunamiFrequencySelectionIndex()
+        {
+            for (var i = 0; i < RealTimeTsunamiFrequencyOptionValues.Length; i++)
+                if (RealTimeTsunamiFrequencyOptionValues[i] == RealTimeTsunamiFrequency)
+                    return i;
+
+            return 2;
+        }
+
+        public static RealTimeDisasterFrequencyPreset GetRealTimeTsunamiFrequencyFromSelection(int selection)
+        {
+            if (selection < 0 || selection >= RealTimeTsunamiFrequencyOptionValues.Length)
+                return RealTimeDisasterFrequencyPreset.Occasional;
+
+            return RealTimeTsunamiFrequencyOptionValues[selection];
+        }
+
+        public string GetRealTimeTsunamiFrequencyTooltip()
+        {
+            return LocalizationService.Format(
+                "settings.tsunami.realtime_frequency.tooltip.selected",
+                GetRealTimeTsunamiFrequencyName());
+        }
+
+        private string GetRealTimeTsunamiFrequencyName()
+        {
+            switch (RealTimeTsunamiFrequency)
+            {
+                case RealTimeDisasterFrequencyPreset.Apocalypse:
+                    return LocalizationService.Get("settings.tsunami.frequency_name.apocalypse");
+                case RealTimeDisasterFrequencyPreset.Frequent:
+                    return LocalizationService.Get("settings.tsunami.frequency_name.frequent");
+                case RealTimeDisasterFrequencyPreset.Occasional:
+                    return LocalizationService.Get("settings.tsunami.frequency_name.occasional");
+                case RealTimeDisasterFrequencyPreset.Uncommon:
+                    return LocalizationService.Get("settings.tsunami.frequency_name.uncommon");
+                case RealTimeDisasterFrequencyPreset.Rare:
+                    return LocalizationService.Get("settings.tsunami.frequency_name.rare");
+                default:
+                    return RealTimeTsunamiFrequency.ToString();
+            }
         }
     }
 }

--- a/Source/Serialization/NaturalDisaster/SerializableDataTsunami.cs
+++ b/Source/Serialization/NaturalDisaster/SerializableDataTsunami.cs
@@ -1,6 +1,7 @@
 using ColossalFramework;
 using NaturalDisastersRenewal.Common;
 using ColossalFramework.IO;
+using NaturalDisastersRenewal.Common.enums;
 using NaturalDisastersRenewal.Handlers;
 using NaturalDisastersRenewal.Models.NaturalDisaster;
 
@@ -14,6 +15,9 @@ namespace NaturalDisastersRenewal.Serialization.NaturalDisaster
             SerializeCommonParameters(dataSerializer, tsunami);
 
             dataSerializer.WriteFloat(tsunami.WarmupYears);
+            dataSerializer.WriteInt32((int)tsunami.RealTimeTsunamiFrequency);
+            dataSerializer.WriteFloat(tsunami.RealTimeCurrentTsunamiPeriodMinutes);
+            dataSerializer.WriteFloat(tsunami.RealTimeMinutesUntilNextTsunami);
         }
 
         public void Deserialize(DataSerializer dataSerializer)
@@ -22,6 +26,14 @@ namespace NaturalDisastersRenewal.Serialization.NaturalDisaster
             DeserializeCommonParameters(dataSerializer, tsunami);
 
             tsunami.WarmupYears = dataSerializer.ReadFloat();
+
+            if (dataSerializer.version >= 17)
+            {
+                tsunami.RealTimeTsunamiFrequency =
+                    (RealTimeDisasterFrequencyPreset)dataSerializer.ReadInt32();
+                tsunami.RealTimeCurrentTsunamiPeriodMinutes = dataSerializer.ReadFloat();
+                tsunami.RealTimeMinutesUntilNextTsunami = dataSerializer.ReadFloat();
+            }
         }
 
         public void AfterDeserialize(DataSerializer dataSerializer)

--- a/Source/Serialization/Setup/LoadedGameSerializableDataExtension.cs
+++ b/Source/Serialization/Setup/LoadedGameSerializableDataExtension.cs
@@ -12,7 +12,7 @@ namespace NaturalDisastersRenewal.Serialization.Setup
     public class LoadedGameSerializableDataExtension : ISerializableDataExtension
     {
         private const string DataID = CommonProperties.DataId;
-        private const uint DataVersion = 16;
+        private const uint DataVersion = 17;
         private ISerializableData _serializableData;
 
         public void OnCreated(ISerializableData serializedData)

--- a/Source/UI/ComponentHelper/DisasterRowHelper.cs
+++ b/Source/UI/ComponentHelper/DisasterRowHelper.cs
@@ -107,6 +107,8 @@ namespace NaturalDisastersRenewal.UI.ComponentHelper
                     return forestFire.GetRealTimePatternProbabilityProgress();
                 case TornadoModel tornado when tornado.IsRealTimePatternActive():
                     return tornado.GetRealTimePatternProbabilityProgress();
+                case TsunamiModel tsunami:
+                    return tsunami.GetProbabilityProgress();
                 case EarthquakeModel earthquake:
                     return earthquake.GetProbabilityProgress();
                 default:

--- a/Source/UI/ModSettingsScreen.cs
+++ b/Source/UI/ModSettingsScreen.cs
@@ -110,6 +110,8 @@ namespace NaturalDisastersRenewal.UI
 
         private UISlider UI_Tsunami_MaxProbability;
         private UISlider UI_Tsunami_WarmupYears;
+        private UIDropDown UI_Tsunami_RealTimeFrequency;
+        private UISprite UI_Tsunami_RealTimeFrequencyWarning;
         private UIDropDown UI_Tsunami_EvacuationMode;
 
         //Earthquake
@@ -259,6 +261,11 @@ namespace NaturalDisastersRenewal.UI
             UI_Tsunami_EvacuationMode.selectedIndex = (int)disasterSetupModel.Tsunami.EvacuationMode;
             UI_Tsunami_MaxProbability.value = disasterSetupModel.Tsunami.BaseOccurrencePerYear;
             UI_Tsunami_WarmupYears.value = disasterSetupModel.Tsunami.WarmupYears;
+            UI_Tsunami_RealTimeFrequency.selectedIndex =
+                disasterSetupModel.Tsunami.GetRealTimeTsunamiFrequencySelectionIndex();
+            UI_Tsunami_RealTimeFrequency.tooltip =
+                disasterSetupModel.Tsunami.GetRealTimeTsunamiFrequencyTooltip();
+            SetTsunamiRealTimeControlsAvailability(disasterSetupModel.Tsunami.IsRealTimePatternActive());
 
             UI_Earthquake_Enabled.isChecked = disasterSetupModel.Earthquake.Enabled;
             UI_Earthquake_EvacuationMode.selectedIndex = (int)disasterSetupModel.Earthquake.EvacuationMode;
@@ -700,6 +707,8 @@ namespace NaturalDisastersRenewal.UI
             UI_Tsunami_Enabled = null;
             UI_Tsunami_MaxProbability = null;
             UI_Tsunami_WarmupYears = null;
+            UI_Tsunami_RealTimeFrequency = null;
+            UI_Tsunami_RealTimeFrequencyWarning = null;
             UI_Tsunami_EvacuationMode = null;
             UI_Earthquake_Enabled = null;
             UI_Earthquake_MinIntensityToCrack = null;
@@ -1022,6 +1031,7 @@ namespace NaturalDisastersRenewal.UI
             disasterContainer.Thunderstorm.SetRealTimeThunderstormFrequency(frequency);
             disasterContainer.Sinkhole.SetRealTimeSinkholeFrequency(frequency);
             disasterContainer.Tornado.SetRealTimeTornadoFrequency(frequency);
+            disasterContainer.Tsunami.SetRealTimeTsunamiFrequency(frequency);
             disasterContainer.Earthquake.SetRealTimeEarthquakeFrequency(frequency);
             disasterContainer.MeteorStrike.SetRealTimeMeteorFrequency(frequency);
         }
@@ -1080,6 +1090,14 @@ namespace NaturalDisastersRenewal.UI
                 disasterContainer.Tornado.GetRealTimeTornadoFrequencySelectionIndex(),
                 disasterContainer.Tornado.RealTimeTornadoFrequency != disasterContainer.RealTimeFrequencyHarmony,
                 disasterContainer.Tornado.GetRealTimeTornadoFrequencyTooltip());
+
+            SetFrequencyDropdownWarning(
+                UI_Tsunami_RealTimeFrequency,
+                UI_Tsunami_RealTimeFrequencyWarning,
+                TsunamiModel.GetRealTimeTsunamiFrequencyOptions(),
+                disasterContainer.Tsunami.GetRealTimeTsunamiFrequencySelectionIndex(),
+                disasterContainer.Tsunami.RealTimeTsunamiFrequency != disasterContainer.RealTimeFrequencyHarmony,
+                disasterContainer.Tsunami.GetRealTimeTsunamiFrequencyTooltip());
 
             SetFrequencyDropdownWarning(
                 UI_Earthquake_RealTimeFrequency,
@@ -1668,6 +1686,32 @@ namespace NaturalDisastersRenewal.UI
                 LocalizationService.Get("settings.tsunami.warmup.tooltip"));
 
             DropDownHelper.AddDropDown(
+                ref UI_Tsunami_RealTimeFrequency,
+                ref tsunamiGroup,
+                LocalizationService.Get("settings.tsunami.realtime_frequency"),
+                TsunamiModel.GetRealTimeTsunamiFrequencyOptions(),
+                ref disasterContainer.Tsunami.RealTimeTsunamiFrequency,
+                delegate(int selection)
+                {
+                    if (!_freezeUI)
+                    {
+                        disasterContainer.Tsunami.SetRealTimeTsunamiFrequency(
+                            TsunamiModel.GetRealTimeTsunamiFrequencyFromSelection(selection));
+                        UI_Tsunami_RealTimeFrequency.tooltip =
+                            disasterContainer.Tsunami.GetRealTimeTsunamiFrequencyTooltip();
+                        RefreshRealTimeFrequencyHarmonyWarnings(disasterContainer);
+                    }
+                });
+            UI_Tsunami_RealTimeFrequency.selectedIndex =
+                disasterContainer.Tsunami.GetRealTimeTsunamiFrequencySelectionIndex();
+            UI_Tsunami_RealTimeFrequency.tooltip =
+                disasterContainer.Tsunami.GetRealTimeTsunamiFrequencyTooltip();
+            UI_Tsunami_RealTimeFrequencyWarning =
+                CreateFrequencyWarningIcon(UI_Tsunami_RealTimeFrequency);
+            SetTsunamiRealTimeControlsAvailability(disasterContainer.Tsunami.IsRealTimePatternActive());
+            RefreshRealTimeFrequencyHarmonyWarnings(disasterContainer);
+
+            DropDownHelper.AddDropDown(
                 ref UI_Tsunami_EvacuationMode,
                 ref tsunamiGroup,
                 EvacuationModeText,
@@ -1680,6 +1724,18 @@ namespace NaturalDisastersRenewal.UI
             );
 
             helper.AddSpacing(20);
+        }
+
+        private void SetTsunamiRealTimeControlsAvailability(bool realTimeActive)
+        {
+            if (UI_Tsunami_MaxProbability != null)
+                UI_Tsunami_MaxProbability.isEnabled = !realTimeActive;
+
+            if (UI_Tsunami_WarmupYears != null)
+                UI_Tsunami_WarmupYears.isEnabled = !realTimeActive;
+
+            if (UI_Tsunami_RealTimeFrequency != null)
+                UI_Tsunami_RealTimeFrequency.isEnabled = realTimeActive;
         }
 
         private void SetupEarthquake(ref UIHelper helper, DisasterSetupModel disasterContainer)


### PR DESCRIPTION
This pull request adds comprehensive support for configuring and displaying real-time tsunami frequency settings in both the UI and serialization logic. It introduces new UI controls for selecting tsunami frequency presets when "Real Time" mode is active, updates localization for these new options in English and Spanish, and ensures the new settings are properly serialized and deserialized with versioning support. Additionally, it improves UI interactivity and warning displays related to tsunami settings.

**UI enhancements for tsunami frequency:**

* Added a new dropdown (`UI_Tsunami_RealTimeFrequency`) and warning icon for selecting real-time tsunami frequency presets in the mod settings screen, with logic to enable/disable related controls based on the active pattern. Also implemented tooltips and warning synchronization for this control. [[1]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484R113-R114) [[2]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484R264-R268) [[3]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484R710-R711) [[4]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484R1034) [[5]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484R1094-R1101) [[6]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484R1688-R1713) [[7]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484R1729-R1740)

**Localization updates:**

* Added English and Spanish localization strings for the new real-time tsunami frequency options, tooltips, and labels, and clarified the warmup tooltip to specify behavior when Real Time is inactive. [[1]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faL300-R323) [[2]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faL789-R834)

**Serialization and versioning:**

* Updated tsunami serialization to include new real-time frequency fields, with versioning logic to ensure backward compatibility. Increased the data version to 17. [[1]](diffhunk://#diff-63c24e602531d9cb9fe94c38b58fe742b230579812913d4c22430c9e8d4870c8R4) [[2]](diffhunk://#diff-63c24e602531d9cb9fe94c38b58fe742b230579812913d4c22430c9e8d4870c8R18-R20) [[3]](diffhunk://#diff-63c24e602531d9cb9fe94c38b58fe742b230579812913d4c22430c9e8d4870c8R29-R36) [[4]](diffhunk://#diff-84ac309da73fd8e15c9713de2947cb89b036dad5678fc1adcd395f992a8bd14bL15-R15)

**Model and probability progress updates:**

* Ensured the UI displays the correct probability progress for tsunamis by calling `GetProbabilityProgress()` for `TsunamiModel`.

**Codebase maintainability:**

* Changed `SetupAutomaticFocusedEvacuation` in `DisasterBaseModel` to be `protected virtual` to allow for easier extension or override in derived classes.