### PR TITLE
Ndrm 001

### DIFF
--- a/Source/Common/CommonProperties.cs
+++ b/Source/Common/CommonProperties.cs
@@ -5,7 +5,13 @@ namespace NaturalDisastersRenewal.Common
 {
     public static class CommonProperties
     {
+        // For development Purpose//////////////////////
+        
+
+        ///
+        ///////////////////////////////////////////////
         public const string ModName = "Natural Disasters Renewal";
+
         public const string ModNameForHarmony = "NaturalDisastersRenewal";
         public const string ModVersion = "1.3.0";
         public const string ModSteamId = "2957578256";
@@ -17,6 +23,7 @@ namespace NaturalDisastersRenewal.Common
         public const string DataId = "NaturalDisastersRenewalMod";
         public const string DisasterListFileName = "DisasterList.csv";
         public const string LogMessagePrefix = ">>> " + ModName + ": ";
+
 
         public static readonly string NewLine = $"{Environment.NewLine}";
 

--- a/Source/Common/CommonProperties.cs
+++ b/Source/Common/CommonProperties.cs
@@ -5,11 +5,6 @@ namespace NaturalDisastersRenewal.Common
 {
     public static class CommonProperties
     {
-        // For development Purpose//////////////////////
-        
-
-        ///
-        ///////////////////////////////////////////////
         public const string ModName = "Natural Disasters Renewal";
 
         public const string ModNameForHarmony = "NaturalDisastersRenewal";

--- a/Source/Common/Development/DevelopmentProperties.cs
+++ b/Source/Common/Development/DevelopmentProperties.cs
@@ -1,0 +1,7 @@
+namespace NaturalDisastersRenewal.Common.Development
+{
+    public static class DevelopmentProperties
+    {
+        public const bool IsDevelopmentMode = false;
+    }
+}

--- a/Source/Common/LocalizationService.cs
+++ b/Source/Common/LocalizationService.cs
@@ -159,17 +159,17 @@ namespace NaturalDisastersRenewal.Common
                         { "settings.debug.progress.disaster", "Disaster" },
                         {
                             "settings.debug.progress.disaster.tooltip",
-                            "DEBUG only. Selects which disaster receives the test progress value."
+                            "DEV only. Selects which disaster receives the test progress value."
                         },
                         { "settings.debug.progress.percent", "Set progress" },
                         { "settings.debug.progress.force_enabled", "Force Selected progress" },
                         {
                             "settings.debug.progress.force_enabled.tooltip",
-                            "DEBUG only. Enables applying a test progress value to the selected disaster. After applying it, normal progression continues."
+                            "DEV only. Enables applying a test progress value to the selected disaster. After applying it, normal progression continues."
                         },
                         {
                             "settings.debug.progress.percent.tooltip",
-                            "DEBUG only. Progress value to apply while force selected progress is enabled. Moving the slider applies a new value; 100% forces the next occurrence attempt."
+                            "DEV only. Progress value to apply while force selected progress is enabled. Moving the slider applies a new value; 100% forces the next occurrence attempt."
                         },
                         { "settings.frequency.apocalypse", "Apocalypse" },
                         { "settings.frequency.frequent", "Frequent" },
@@ -686,17 +686,17 @@ namespace NaturalDisastersRenewal.Common
                         { "settings.debug.progress.disaster", "Desastre" },
                         {
                             "settings.debug.progress.disaster.tooltip",
-                            "Solo DEBUG. Selecciona que desastre recibe el valor de progreso de prueba."
+                            "Solo DEV. Selecciona que desastre recibe el valor de progreso de prueba."
                         },
                         { "settings.debug.progress.percent", "Definir progreso" },
                         { "settings.debug.progress.force_enabled", "Forzar progreso seleccionado" },
                         {
                             "settings.debug.progress.force_enabled.tooltip",
-                            "Solo DEBUG. Habilita aplicar un valor de progreso de prueba al desastre seleccionado. Luego de aplicarlo, la progresion normal continua."
+                            "Solo DEV. Habilita aplicar un valor de progreso de prueba al desastre seleccionado. Luego de aplicarlo, la progresion normal continua."
                         },
                         {
                             "settings.debug.progress.percent.tooltip",
-                            "Solo DEBUG. Valor de progreso que se aplica mientras Forzar progreso seleccionado esta activo. Mover el slider aplica un nuevo valor; 100% fuerza el proximo intento de ocurrencia."
+                            "Solo DEV. Valor de progreso que se aplica mientras Forzar progreso seleccionado esta activo. Mover el slider aplica un nuevo valor; 100% fuerza el proximo intento de ocurrencia."
                         },
                         { "settings.frequency.apocalypse", "Apocalipsis" },
                         { "settings.frequency.frequent", "Frecuente" },

--- a/Source/NaturalDisastersRenewal.csproj
+++ b/Source/NaturalDisastersRenewal.csproj
@@ -63,6 +63,7 @@
     <ItemGroup>
         <Compile Include="Common\BuildInfo.cs"/>
         <Compile Include="Common\CommonProperties.cs"/>
+        <Compile Include="Common\Development\DevelopmentProperties.cs"/>
         <Compile Include="Common\DisasterRecurrenceTuning.cs"/>
         <Compile Include="Common\HotkeyHelper.cs"/>
         <Compile Include="Common\LocalizationService.cs"/>
@@ -112,8 +113,8 @@
         <Compile Include="UI\ComponentHelper\HotkeyFieldHelper.cs"/>
         <Compile Include="UI\ComponentHelper\UIStyleHelper.cs"/>
         <Compile Include="UI\ComponentHelper\TabHelper.cs"/>
-        <Compile Include="UI\InGameDisastersPanel.cs" />
-        <Compile Include="UI\ShelterHoverDebugOverlay.cs" />
+        <Compile Include="UI\InGameDisastersPanel.cs"/>
+        <Compile Include="UI\ShelterHoverDebugOverlay.cs"/>
         <Compile Include="Common\DisasterSimulationUtils.cs"/>
         <Compile Include="BaseGameExtensions\LoadingExtension.cs"/>
         <Compile Include="Common\enums\OccurrenceAreas.cs"/>
@@ -126,7 +127,7 @@
         <Compile Include="UI\Extensions\UIHelperExtensions.cs"/>
         <Compile Include="UI\SettingsSections\AboutSettingsSection.cs"/>
         <Compile Include="UI\SettingsSections\DependenciesSettingsSection.cs"/>
-        <Compile Include="UI\ModSettingsScreen.cs" />
+        <Compile Include="UI\ModSettingsScreen.cs"/>
     </ItemGroup>
     <ItemGroup>
         <None Include="packages.config"/>
@@ -155,18 +156,18 @@
         <EmbeddedResource Include="Resources\Images\mod_compatibility.png"/>
         <EmbeddedResource Include="Resources\Images\github.png"/>
         <EmbeddedResource Include="Resources\Images\kofi_dark.png"/>
-        <EmbeddedResource Include="Resources\Images\steam.png" />
-        <EmbeddedResource Include="Resources\Images\icons\Warning-Conflict.svg" />
-        <EmbeddedResource Include="Resources\Images\icons\Warning.svg" />
-        <EmbeddedResource Include="Resources\Images\icons\Warning2.svg" />
-        <EmbeddedResource Include="Resources\Images\icons\Restart.svg" />
-        <EmbeddedResource Include="Resources\Images\icons\Stop.svg" />
-        <EmbeddedResource Include="Resources\Images\icons\Stop2.svg" />
+        <EmbeddedResource Include="Resources\Images\steam.png"/>
+        <EmbeddedResource Include="Resources\Images\icons\Warning-Conflict.svg"/>
+        <EmbeddedResource Include="Resources\Images\icons\Warning.svg"/>
+        <EmbeddedResource Include="Resources\Images\icons\Warning2.svg"/>
+        <EmbeddedResource Include="Resources\Images\icons\Restart.svg"/>
+        <EmbeddedResource Include="Resources\Images\icons\Stop.svg"/>
+        <EmbeddedResource Include="Resources\Images\icons\Stop2.svg"/>
         <Content Include="Versions\Changelog.txt"/>
         <Content Include="Versions\FutureWork\FutureWork.txt"/>
     </ItemGroup>
     <ItemGroup>
-      <Folder Include="Versions\FutureWork\" />
+        <Folder Include="Versions\FutureWork\"/>
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
     <Target Name="GenerateBuildInfo" BeforeTargets="BeforeBuild">

--- a/Source/UI/ModSettingsScreen.cs
+++ b/Source/UI/ModSettingsScreen.cs
@@ -7,6 +7,7 @@ using ColossalFramework.UI;
 using ICities;
 using NaturalDisastersRenewal.BaseGameExtensions;
 using NaturalDisastersRenewal.Common;
+using NaturalDisastersRenewal.Common.Development;
 using NaturalDisastersRenewal.Common.enums;
 using NaturalDisastersRenewal.Models.NaturalDisaster;
 using NaturalDisastersRenewal.Models.Setup;
@@ -62,13 +63,11 @@ namespace NaturalDisastersRenewal.UI
         private UICheckBox UI_General_RecordDisasterEventsChkBox;
         private UICheckBox UI_General_ShowDisasterPanelButton;
         private UITextField UI_General_TogglePanelHotkeyField;
-#if DEBUG
         private UIDropDown UI_Debug_DisasterProgressTarget;
         private UICheckBox UI_Debug_DisasterProgressEnabled;
         private UISlider UI_Debug_DisasterProgress;
         private int debugDisasterProgressTargetIndex;
         private int debugForcedDisasterProgressIndex = -1;
-#endif
 
         //Forest Fire
         private UICheckBox UI_ForestFire_Enabled;
@@ -696,13 +695,11 @@ namespace NaturalDisastersRenewal.UI
             UI_General_RecordDisasterEventsChkBox = null;
             UI_General_ShowDisasterPanelButton = null;
             UI_General_TogglePanelHotkeyField = null;
-#if DEBUG
             UI_Debug_DisasterProgressTarget = null;
             UI_Debug_DisasterProgressEnabled = null;
             UI_Debug_DisasterProgress = null;
             debugDisasterProgressTargetIndex = 0;
             debugForcedDisasterProgressIndex = -1;
-#endif
             UI_ForestFire_Enabled = null;
             UI_ForestFireMaxProbability = null;
             UI_ForestFire_WarmupDays = null;
@@ -958,9 +955,10 @@ namespace NaturalDisastersRenewal.UI
             UI_General_RealTimeFrequencyHarmony.tooltip = GetRealTimeFrequencyHarmonyTooltip();
             SetRealTimeFrequencyHarmonyAvailability(DisasterSimulationUtils.IsRealTimeModActive());
 
-#if DEBUG
-            AddDebugDisasterProgressControls(ref generalGroup, disasterContainer);
-#endif
+#pragma warning disable CS0162
+            if (DevelopmentProperties.IsDevelopmentMode)
+                AddDebugDisasterProgressControls(ref generalGroup, disasterContainer);
+#pragma warning restore CS0162
 
             generalGroup.AddSpacing();
 
@@ -979,7 +977,6 @@ namespace NaturalDisastersRenewal.UI
             });
         }
 
-#if DEBUG
         private void AddDebugDisasterProgressControls(ref UIHelperBase generalGroup,
             DisasterSetupModel disasterContainer)
         {
@@ -1097,7 +1094,6 @@ namespace NaturalDisastersRenewal.UI
             if (UI_Debug_DisasterProgress != null)
                 UI_Debug_DisasterProgress.isEnabled = enabled;
         }
-#endif
 
         private UISlider AddMaxGeneratedIntensitySlider(ref UIHelperBase group, DisasterBaseModel disaster)
         {

--- a/Source/UI/ShelterHoverDebugOverlay.cs
+++ b/Source/UI/ShelterHoverDebugOverlay.cs
@@ -4,9 +4,10 @@ using System.Reflection;
 using ColossalFramework;
 using ColossalFramework.UI;
 using NaturalDisastersRenewal.Common;
+using NaturalDisastersRenewal.Common.Development;
 using NaturalDisastersRenewal.Models.NaturalDisaster;
 using UnityEngine;
-//
+
 namespace NaturalDisastersRenewal.UI
 {
     public class ShelterHoverDebugOverlay : UIPanel
@@ -20,12 +21,13 @@ namespace NaturalDisastersRenewal.UI
         private const float MinMeteorWaterWaveReach = 2560f;
         private const float MaxMeteorWaterWaveReach = 7680f;
         private const float SimulationFramesPerSecond = 60f;
+
         private static readonly FieldInfo HoverInstanceField =
             typeof(DefaultTool).GetField("m_hoverInstance", BindingFlags.Instance | BindingFlags.NonPublic);
 
         private readonly HashSet<ulong> _clearedMeteorShelterKeys = new HashSet<ulong>();
-        private readonly Dictionary<ulong, uint> _waterContactFrameByMeteorShelter = new Dictionary<ulong, uint>();
         private readonly Dictionary<ulong, uint> _meteorImpactFrameByMeteorShelter = new Dictionary<ulong, uint>();
+        private readonly Dictionary<ulong, uint> _waterContactFrameByMeteorShelter = new Dictionary<ulong, uint>();
         private UILabel _label;
         private UIView _view;
 
@@ -91,18 +93,14 @@ namespace NaturalDisastersRenewal.UI
             bool isFlooded;
 
             if (!TryGetShelterStreetFloodState(ref building, out segmentId, out waterDepth, out isFlooded))
-            {
                 _label.text = string.Format("Shelter {0}\nCalle: desconocida", shelterId);
-            }
             else
-            {
                 _label.text = string.Format(
                     "Shelter {0}\nCalle: {1}\nSegmento: {2}\nAgua: {3:0.00}",
                     shelterId,
                     isFlooded ? "inundada" : "seca",
                     segmentId,
                     waterDepth);
-            }
 
             string meteorInfo;
             if (TryGetNearbyMeteorWaterImpactInfo(shelterId, building.m_position, waterDepth, out meteorInfo))
@@ -128,12 +126,12 @@ namespace NaturalDisastersRenewal.UI
 
             var foundMeteor = false;
             ushort bestDisasterId = 0;
-            float bestDistance = float.MaxValue;
+            var bestDistance = float.MaxValue;
             byte bestIntensity = 0;
-            uint bestImpactFrame = 0u;
-            bool bestHasImpactFrame = false;
-            bool bestImpactFrameIsFallback = false;
-            bool bestIsActive = false;
+            var bestImpactFrame = 0u;
+            var bestHasImpactFrame = false;
+            var bestImpactFrameIsFallback = false;
+            var bestIsActive = false;
 
             for (var disasterIndex = 0; disasterIndex < disasterManager.m_disasters.m_buffer.Length; disasterIndex++)
             {
@@ -409,11 +407,7 @@ namespace NaturalDisastersRenewal.UI
 
         private static bool IsDevelopmentModeEnabled()
         {
-#if DEBUG
-            return true;
-#else
-            return false;
-#endif
+            return DevelopmentProperties.IsDevelopmentMode;
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a new development mode flag to the codebase, replacing previous `#if DEBUG` preprocessor directives with a runtime property. This makes it easier to control development-only features without needing to recompile the code in debug mode. Additionally, it updates various UI strings to refer to "DEV" instead of "DEBUG" and refactors related code for clarity and maintainability.

**Development mode control and refactoring:**

* Added a new `DevelopmentProperties` class with a boolean `IsDevelopmentMode` flag, and replaced `#if DEBUG` conditionals with runtime checks using this flag throughout the codebase. This enables toggling development features without recompiling. [[1]](diffhunk://#diff-ba47df1c89645e2569e8f024d42aa86c41b91c373516a7039a7b8a7041ef11afR1-R7) [[2]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484L961-R961) [[3]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484L65-L71) [[4]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484L699-L705) [[5]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484L982) [[6]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484L1100) [[7]](diffhunk://#diff-d718e04b274f56aaac3e3f45c2accc5c270e312a0861d0722fc04a9679976662L412-R410) [[8]](diffhunk://#diff-c205b4fa39bd7333115d82f539668a1ed55146da4f2765df592f6178d077e2bdR66) [[9]](diffhunk://#diff-7973d0a1b027c5d26de491c45da7603f8fd56ef3bb1d219ec6ca88306dcca484R10) [[10]](diffhunk://#diff-d718e04b274f56aaac3e3f45c2accc5c270e312a0861d0722fc04a9679976662R7-R10)
* Updated the `ShelterHoverDebugOverlay` and related UI logic to use the new development mode flag, improving code clarity and maintainability. [[1]](diffhunk://#diff-d718e04b274f56aaac3e3f45c2accc5c270e312a0861d0722fc04a9679976662L412-R410) [[2]](diffhunk://#diff-d718e04b274f56aaac3e3f45c2accc5c270e312a0861d0722fc04a9679976662R7-R10) [[3]](diffhunk://#diff-d718e04b274f56aaac3e3f45c2accc5c270e312a0861d0722fc04a9679976662R24-R30)

**UI and localization improvements:**

* Changed all references in tooltips and labels from "DEBUG" to "DEV" in both English and Spanish localizations, reflecting the new development mode terminology. [[1]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faL162-R172) [[2]](diffhunk://#diff-decf772d1df9395c1f20ed8deda5c172fb4e5084cae17571a3534aed891122faL689-R699)

**Minor code and style improvements:**

* Minor code cleanups and reordering in `ShelterHoverDebugOverlay` for consistency. [[1]](diffhunk://#diff-d718e04b274f56aaac3e3f45c2accc5c270e312a0861d0722fc04a9679976662R24-R30) [[2]](diffhunk://#diff-d718e04b274f56aaac3e3f45c2accc5c270e312a0861d0722fc04a9679976662L94-L105) [[3]](diffhunk://#diff-d718e04b274f56aaac3e3f45c2accc5c270e312a0861d0722fc04a9679976662L131-R134)
* Added newlines and minor formatting adjustments in `CommonProperties`. [[1]](diffhunk://#diff-3c820e90167712a8df5373b6c889a642852291dc22077f171ddfc7ea190b82a3R9) [[2]](diffhunk://#diff-3c820e90167712a8df5373b6c889a642852291dc22077f171ddfc7ea190b82a3R22)

These changes collectively make it easier to enable or disable development features, improve maintainability, and ensure clearer communication in the UI.