### PR TITLE
Enhance UI element position synchronization and persistence for disasters

### DIFF
--- a/Source/Handlers/NaturalDisasterHandler.cs
+++ b/Source/Handlers/NaturalDisasterHandler.cs
@@ -25,6 +25,8 @@ namespace NaturalDisastersRenewal.Handlers
         private bool keyHandlerRegistered;
         private ShelterHoverDebugOverlay shelterHoverDebugOverlay;//
         private UIButton toggleButton;
+        private bool panelPositionChanged;
+        private bool toggleButtonPositionChanged;
 
         private NaturalDisasterHandler()
         {
@@ -328,7 +330,7 @@ namespace NaturalDisastersRenewal.Handlers
             var obj = new GameObject("InGameDisastersPanel");
             obj.transform.parent = v.cachedTransform;
             dPanel = obj.AddComponent<InGameDisastersPanel>();
-            dPanel.absolutePosition = DefaultPanelPosition;
+            dPanel.absolutePosition = GetVisibleUIPosition(container.DPanelPos, dPanel, DefaultPanelPosition);
 
             EnsureShelterHoverDebugOverlay();
 
@@ -340,14 +342,19 @@ namespace NaturalDisastersRenewal.Handlers
             ApplyDefaultToggleButtonSprites();
             toggleButton.width = 48f;
             toggleButton.height = 48f;
-            toggleButton.absolutePosition = DefaultToggleButtonPosition;
+            toggleButton.absolutePosition = GetVisibleUIPosition(
+                container.ToggleButtonPos,
+                toggleButton,
+                DefaultToggleButtonPosition);
             toggleButton.tooltip = LocalizationService.Get("panel.toggle_button.tooltip");
             toggleButton.isVisible = container.ShowDisasterPanelButton;
             toggleButton.eventClick += ToggleButton_eventClick;
             toggleButton.eventMouseMove += ToggleButton_eventMouseMove;
+            toggleButton.eventMouseUp += ToggleButton_eventMouseUp;
 
             dPanel.tooltip = LocalizationService.Get("panel.drag_panel.tooltip");
             dPanel.eventMouseMove += DPanel_eventMouseMove;
+            dPanel.eventMouseUp += DPanel_eventMouseUp;
 
             UpdateDisastersPanelToggleBtn();
             UpdateDisastersDPanel();
@@ -417,6 +424,27 @@ namespace NaturalDisastersRenewal.Handlers
             dPanel.RebuildLocalizedContent();
         }
 
+        public void SyncInterfaceElementPositions()
+        {
+            if (container == null)
+                return;
+
+            if (toggleButton != null)
+            {
+                var visiblePosition = GetVisibleUIPosition(
+                    toggleButton.absolutePosition,
+                    toggleButton,
+                    DefaultToggleButtonPosition);
+                container.ToggleButtonPos = visiblePosition;
+            }
+
+            if (dPanel != null)
+            {
+                var visiblePosition = GetVisibleUIPosition(dPanel.absolutePosition, dPanel, DefaultPanelPosition);
+                container.DPanelPos = visiblePosition;
+            }
+        }
+
         public DisasterWrapper GetDisasterWrapper()
         {
             return disasterWrapper;
@@ -464,6 +492,16 @@ namespace NaturalDisastersRenewal.Handlers
             toggleButton.position = SetUIItemPosition(toggleButton.position, eventParam.moveDelta.x,
                 eventParam.moveDelta.y, ratio);
             container.ToggleButtonPos = toggleButton.absolutePosition;
+            toggleButtonPositionChanged = true;
+        }
+
+        private void ToggleButton_eventMouseUp(UIComponent component, UIMouseEventParameter eventParam)
+        {
+            if (!toggleButtonPositionChanged) return;
+
+            toggleButtonPositionChanged = false;
+            SyncInterfaceElementPositions();
+            SaveInterfaceElementPositionsToFile();
         }
 
         private void DPanel_eventMouseMove(UIComponent component, UIMouseEventParameter eventParam)
@@ -474,7 +512,29 @@ namespace NaturalDisastersRenewal.Handlers
                 dPanel.position =
                     SetUIItemPosition(dPanel.position, eventParam.moveDelta.x, eventParam.moveDelta.y, ratio);
                 container.DPanelPos = dPanel.absolutePosition;
+                panelPositionChanged = true;
             }
+        }
+
+        private void DPanel_eventMouseUp(UIComponent component, UIMouseEventParameter eventParam)
+        {
+            if (!panelPositionChanged) return;
+
+            panelPositionChanged = false;
+            SyncInterfaceElementPositions();
+            SaveInterfaceElementPositionsToFile();
+        }
+
+        private void SaveInterfaceElementPositionsToFile()
+        {
+            if (container == null)
+                return;
+
+            var defaultSettings = DisasterSetupModel.CreateFromFile() ?? new DisasterSetupModel();
+            defaultSettings.CheckObjects();
+            defaultSettings.ToggleButtonPos = container.ToggleButtonPos;
+            defaultSettings.DPanelPos = container.DPanelPos;
+            defaultSettings.Save();
         }
 
         private Vector3 SetUIItemPosition(Vector3 currentPosition, float x, float y, float ratio)

--- a/Source/Serialization/Setup/SerializableDataDisasterSetup.cs
+++ b/Source/Serialization/Setup/SerializableDataDisasterSetup.cs
@@ -12,6 +12,7 @@ namespace NaturalDisastersRenewal.Serialization.Setup
     {
         public void Serialize(DataSerializer dataSerializer)
         {
+            Services.DisasterHandler.SyncInterfaceElementPositions();
             DisasterSetupModel disasterSetupmodel = Services.DisasterSetup;
 
             dataSerializer.WriteBool(disasterSetupmodel.ScaleMaxIntensityWithPopulation);


### PR DESCRIPTION
This pull request introduces improvements to the handling and persistence of UI element positions for the natural disaster panel and its toggle button. The main focus is on ensuring that any changes to the positions of these interface elements are saved and restored properly, providing a better user experience.

**UI Position Persistence and Sync Improvements:**

* Added tracking for when the panel or toggle button positions are changed (`panelPositionChanged`, `toggleButtonPositionChanged`) to `NaturalDisasterHandler`, and hooked into mouse events to trigger saving of positions.
* Updated the creation of the disaster panel and toggle button to use a visibility-aware position function, ensuring UI elements are always placed within visible bounds. [[1]](diffhunk://#diff-887b2db1359e5715d74b48141b952bae9deb56ae5ea6de8e09f0da47d529f9e3L331-R333) [[2]](diffhunk://#diff-887b2db1359e5715d74b48141b952bae9deb56ae5ea6de8e09f0da47d529f9e3L343-R357)

**Event Handling and Saving Logic:**

* Registered `eventMouseUp` handlers for both the panel and toggle button; on mouse release after movement, the new positions are synced and saved to file for persistence. [[1]](diffhunk://#diff-887b2db1359e5715d74b48141b952bae9deb56ae5ea6de8e09f0da47d529f9e3L343-R357) [[2]](diffhunk://#diff-887b2db1359e5715d74b48141b952bae9deb56ae5ea6de8e09f0da47d529f9e3R495-R504) [[3]](diffhunk://#diff-887b2db1359e5715d74b48141b952bae9deb56ae5ea6de8e09f0da47d529f9e3R515-R537)
* Added `SyncInterfaceElementPositions` and `SaveInterfaceElementPositionsToFile` methods to centralize logic for updating and persisting UI positions. [[1]](diffhunk://#diff-887b2db1359e5715d74b48141b952bae9deb56ae5ea6de8e09f0da47d529f9e3R427-R447) [[2]](diffhunk://#diff-887b2db1359e5715d74b48141b952bae9deb56ae5ea6de8e09f0da47d529f9e3R515-R537)

**Serialization Integration:**

* Ensured UI positions are synchronized before serialization by calling `SyncInterfaceElementPositions` in `SerializableDataDisasterSetup.Serialize`. This guarantees that the latest UI positions are saved with game data.…ter panel